### PR TITLE
Add aud_sub claim and clarify tenant claim opacity

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -9,7 +9,7 @@ on:
       - LICENSE.md
       - .gitignore
       - '.github/**'
-    branches: ["*"]
+    branches: ["*"]  # Build HTML for all branches
   release:
     types:
       - created
@@ -31,9 +31,6 @@ concurrency:
 
 jobs:
   build-and-deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     env:
         BRANCH_NAME: ${{ github.head_ref || github.ref_name }}

--- a/openid-connect-enterprise-extensions-1_0.md
+++ b/openid-connect-enterprise-extensions-1_0.md
@@ -81,7 +81,11 @@ The `session_expiry` claim is a JSON integer that represents the Unix timestamp 
 
 ## tenant
 
-The `tenant` claim is an opaque JSON string that represents a tenant identifier and MAY have the value `personal`, `organization` or a stable OP unique value for multi-tenant OPs. The `personal` value is reserved for when Accounts are managed by individuals. The `organization` value is reserved for Accounts managed by an organization.
+The `tenant` claim is a JSON string that represents a tenant identifier and MAY have the value `personal`, `organization` or a stable, opaque to the RP, OP unique value for multi-tenant OPs. The `personal` value is reserved for when Accounts are managed by individuals. The `organization` value is reserved for Accounts managed by an organization.
+
+## aud_sub
+
+The `aud_sub` claim is an opaque JSON string that represents the identifier the RP has for the account. How the OP acquires the `aud_sub` and how the OP account and RP account linking is out of scope.
 
 
 # Authentication Request Parameters

--- a/openid-connect-enterprise-extensions-1_0.md
+++ b/openid-connect-enterprise-extensions-1_0.md
@@ -1,5 +1,5 @@
 %%%
-title = "OpenID Connect Enterprise Extensions 1.0 - draft 00"
+title = "OpenID Connect Enterprise Extensions 1.0 - draft 01"
 abbrev = "openid-connect-enterprise-extensions"
 ipr = "none"
 workgroup = "OpenID Connect"
@@ -202,3 +202,7 @@ specification.
    -00
 
    initial draft
+
+   -01
+
+   * added `aud_sub` claim


### PR DESCRIPTION
- Add new aud_sub claim for RP account identifier
- Clarify that tenant claim values should be opaque to the RP
- Specify that OP account and RP account linking is out of scope for aud_sub