### PR TITLE
Added tenancy models and support for aud_tenant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
+SRC    := openid-connect-enterprise-extensions-1_0.md
+XML    := openid-connect-enterprise-extensions-1_0.xml
+HTML   := openid-connect-enterprise-extensions-1_0.html
+
+.PHONY: all html xml clean
+
+all: html
+
+html: $(HTML)
+
+$(HTML): $(XML)
+	mkdir -p html
+	xml2rfc --html $(XML) --out $(HTML)
+
+$(XML): $(SRC)
+	mmark $(SRC) > $(XML)
+
+clean:
+	rm -f $(XML) $(HTML)

--- a/openid-connect-enterprise-extensions-1_0.html
+++ b/openid-connect-enterprise-extensions-1_0.html
@@ -2057,7 +2057,7 @@ the use of <em>this fixed-width font</em>.<a href="#section-1.1-2" class="pilcro
         </table>
 <ul class="compact">
 <li class="compact" id="appendix-A.1-8.1">
-            <strong>Discovery</strong>: If an OP publishes support for the <code>tenant</code> claim in the <code>claims_supported</code> metadata parameter (see [OpenID Connect Discovery 1.0]), then RPs SHOULD assume that the issuer is a multi-tenant OP using a single issuer identifier and SHOULD expect the <code>tenant</code> claim to be present in ID Tokens. The <code>tenant</code> claim value MUST be one of the allowed values for the corresponding OP model as specified in the table in <a href="#tenant">Section "tenant"</a>.<a href="#appendix-A.1-8.1" class="pilcrow">¶</a>
+            <strong>Discovery</strong>: If an OP publishes support for the <code>tenant</code> claim in the <code>claims_supported</code> metadata parameter (see [OpenID Connect Discovery 1.0]), then RPs SHOULD assume that the issuer is a multi-tenant OP using a single issuer identifier and SHOULD expect the <code>tenant</code> claim to be present in ID Tokens with a value of <code>personal</code> or a unique tenant identifier, as specified in <a href="#tenant">Section "tenant"</a>.<a href="#appendix-A.1-8.1" class="pilcrow">¶</a>
 </li>
         </ul>
 </section>

--- a/openid-connect-enterprise-extensions-1_0.html
+++ b/openid-connect-enterprise-extensions-1_0.html
@@ -1484,52 +1484,74 @@ the use of <em>this fixed-width font</em>.<a href="#section-1.1-2" class="pilcro
 <a href="#section-2.2" class="section-number selfRef">2.2. </a><a href="#name-tenant" class="section-name selfRef">tenant</a>
         </h3>
 <p id="section-2.2-1">The <code>tenant</code> claim is a JSON string that represents an OP tenant identifier. This claim is OPTIONAL and MAY be included in ID Tokens.<a href="#section-2.2-1" class="pilcrow">¶</a></p>
+<p id="section-2.2-2">The following well-known values are defined for the <code>tenant</code> claim:<a href="#section-2.2-2" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-2.2-2.1">
-            <p id="section-2.2-2.1.1"><strong>Single-tenant OPs</strong>: Single-tenant OPs SHOULD omit the <code>tenant</code> claim.<a href="#section-2.2-2.1.1" class="pilcrow">¶</a></p>
+<li class="normal" id="section-2.2-3.1">
+            <code>personal</code>: Indicates that accounts are managed by individuals rather than by a specific organizational tenant.<a href="#section-2.2-3.1" class="pilcrow">¶</a>
 </li>
-          <li class="normal" id="section-2.2-2.2">
-            <p id="section-2.2-2.2.1"><strong>Multi-tenant OPs using a single issuer</strong>: Multi-tenant OPs using a single issuer identifier SHOULD include the <code>tenant</code> claim to identify the OP tenant. The value MUST be a stable, opaque to the RP, OP unique identifier or a well known special value described below.<a href="#section-2.2-2.2.1" class="pilcrow">¶</a></p>
+          <li class="normal" id="section-2.2-3.2">
+            <p id="section-2.2-3.2.1"><code>organization</code>: Indicates that accounts are managed by an organization.<a href="#section-2.2-3.2.1" class="pilcrow">¶</a></p>
+</li>
+          <li class="normal" id="section-2.2-3.3">
+            <p id="section-2.2-3.3.1"><strong>Single-tenant OPs</strong>: Single-tenant OPs MAY include the <code>tenant</code> claim. If included, the value MUST be <code>personal</code> or <code>organization</code>.<a href="#section-2.2-3.3.1" class="pilcrow">¶</a></p>
+</li>
+          <li class="normal" id="section-2.2-3.4">
+            <p id="section-2.2-3.4.1"><strong>Multi-tenant OPs using a single issuer</strong>: Multi-tenant OPs using a single issuer identifier SHOULD include the <code>tenant</code> claim to identify the OP tenant. The value MUST be <code>personal</code> or a stable, opaque to the RP, OP unique tenant identifier.<a href="#section-2.2-3.4.1" class="pilcrow">¶</a></p>
 <ul class="compact normal">
-<li class="compact normal" id="section-2.2-2.2.2.1">The combination of <code>iss</code>, <code>tenant</code>, and <code>sub</code> MUST be unique across all OP tenants.<a href="#section-2.2-2.2.2.1" class="pilcrow">¶</a>
+<li class="compact normal" id="section-2.2-3.4.2.1">The combination of <code>iss</code>, <code>tenant</code>, and <code>sub</code> MUST be unique across all OP tenants.<a href="#section-2.2-3.4.2.1" class="pilcrow">¶</a>
 </li>
-              <li class="compact normal" id="section-2.2-2.2.2.2">If the OP uses <code>pairwise</code> subject identifiers, the same user MAY have the same <code>sub</code> for the same <code>client_id</code> regardless of OP tenant. The <code>tenant</code> claim SHOULD be included in the uniqueness requirement (<code>iss</code> + <code>tenant</code> + <code>sub</code>) to disambiguate subjects across tenants.<a href="#section-2.2-2.2.2.2" class="pilcrow">¶</a>
+              <li class="compact normal" id="section-2.2-3.4.2.2">If the OP uses <code>pairwise</code> subject identifiers, the same user MAY have the same <code>sub</code> for the same <code>client_id</code> regardless of OP tenant. The <code>tenant</code> claim SHOULD be included in the uniqueness requirement (<code>iss</code> + <code>tenant</code> + <code>sub</code>) to disambiguate subjects across tenants.<a href="#section-2.2-3.4.2.2" class="pilcrow">¶</a>
 </li>
-              <li class="compact normal" id="section-2.2-2.2.2.3">If the OP uses <code>public</code> subject identifiers, the <code>sub</code> value MUST be the same across all RPs/clients and all OP tenants. The <code>tenant</code> claim MUST be included in the uniqueness requirement (<code>iss</code> + <code>tenant</code> + <code>sub</code>) to disambiguate subjects across tenants.<a href="#section-2.2-2.2.2.3" class="pilcrow">¶</a>
+              <li class="compact normal" id="section-2.2-3.4.2.3">If the OP uses <code>public</code> subject identifiers, the <code>sub</code> value MUST be the same across all RPs/clients and all OP tenants. The <code>tenant</code> claim MUST be included in the uniqueness requirement (<code>iss</code> + <code>tenant</code> + <code>sub</code>) to disambiguate subjects across tenants.<a href="#section-2.2-3.4.2.3" class="pilcrow">¶</a>
 </li>
             </ul>
 </li>
-          <li class="normal" id="section-2.2-2.3">
-            <p id="section-2.2-2.3.1"><strong>Multi-tenant OPs using tenant-specific issuer identifiers</strong>: Multi-tenant OPs using tenant-specific issuer identifiers SHOULD omit the <code>tenant</code> claim since the issuer identifier itself identifies the tenant.<a href="#section-2.2-2.3.1" class="pilcrow">¶</a></p>
+          <li class="normal" id="section-2.2-3.5">
+            <p id="section-2.2-3.5.1"><strong>Multi-tenant OPs using tenant-specific issuer identifiers</strong>: Multi-tenant OPs using tenant-specific issuer identifiers SHOULD omit the <code>tenant</code> claim since the issuer identifier itself identifies the tenant. If the <code>tenant</code> claim is included, the value MUST be <code>personal</code> or <code>organization</code>.<a href="#section-2.2-3.5.1" class="pilcrow">¶</a></p>
 <ul class="compact normal">
-<li class="compact normal" id="section-2.2-2.3.2.1">Each tenant issuer identifier MUST be a valid URL per [OpenID Connect Core 1.0] Section 2.<a href="#section-2.2-2.3.2.1" class="pilcrow">¶</a>
+<li class="compact normal" id="section-2.2-3.5.2.1">Each tenant issuer identifier MUST be a valid URL per [OpenID Connect Core 1.0] Section 2.<a href="#section-2.2-3.5.2.1" class="pilcrow">¶</a>
 </li>
-              <li class="compact normal" id="section-2.2-2.3.2.2">The combination of <code>iss</code> and <code>sub</code> MUST be unique per tenant.<a href="#section-2.2-2.3.2.2" class="pilcrow">¶</a>
+              <li class="compact normal" id="section-2.2-3.5.2.2">The combination of <code>iss</code> and <code>sub</code> MUST be unique per tenant.<a href="#section-2.2-3.5.2.2" class="pilcrow">¶</a>
 </li>
-              <li class="compact normal" id="section-2.2-2.3.2.3">If the OP uses <code>pairwise</code> subject identifiers, the <code>sub</code> value MUST differ across <code>client_id</code> values within each tenant. The combination of <code>iss</code> + <code>client_id</code> + <code>sub</code> MUST be unique across all tenants.<a href="#section-2.2-2.3.2.3" class="pilcrow">¶</a>
+              <li class="compact normal" id="section-2.2-3.5.2.3">If the OP uses <code>pairwise</code> subject identifiers, the <code>sub</code> value MUST differ across <code>client_id</code> values within each tenant. The combination of <code>iss</code> + <code>client_id</code> + <code>sub</code> MUST be unique across all tenants.<a href="#section-2.2-3.5.2.3" class="pilcrow">¶</a>
 </li>
-              <li class="compact normal" id="section-2.2-2.3.2.4">If the OP uses <code>public</code> subject identifiers, the <code>sub</code> value MUST be the same across all RPs/clients within each tenant. The <code>sub</code> value MAY be the same across tenants, but the combination of <code>iss</code> + <code>sub</code> MUST be unique across all tenants.<a href="#section-2.2-2.3.2.4" class="pilcrow">¶</a>
+              <li class="compact normal" id="section-2.2-3.5.2.4">If the OP uses <code>public</code> subject identifiers, the <code>sub</code> value MUST be the same across all RPs/clients within each tenant. The <code>sub</code> value MAY be the same across tenants, but the combination of <code>iss</code> + <code>sub</code> MUST be unique across all tenants.<a href="#section-2.2-3.5.2.4" class="pilcrow">¶</a>
 </li>
             </ul>
 </li>
-          <li class="normal" id="section-2.2-2.4">
-            <p id="section-2.2-2.4.1"><strong>Special values</strong>: The <code>tenant</code> claim MAY have the well-known value <code>personal</code> or <code>organization</code> instead of a unique identifier.<a href="#section-2.2-2.4.1" class="pilcrow">¶</a></p>
-<ul class="compact normal">
-<li class="compact normal" id="section-2.2-2.4.2.1">
-                <code>personal</code>: Indicates that accounts are managed by individuals rather than by a specific organizational tenant.<a href="#section-2.2-2.4.2.1" class="pilcrow">¶</a>
-</li>
-              <li class="compact normal" id="section-2.2-2.4.2.2">
-                <code>organization</code>: Indicates that accounts are managed by an organization.<a href="#section-2.2-2.4.2.2" class="pilcrow">¶</a>
-</li>
-            </ul>
+          <li class="normal" id="section-2.2-3.6">
+            <p id="section-2.2-3.6.1"><strong>Discovery</strong>: If an OP publishes support for the <code>tenant</code> claim in the <code>claims_supported</code> metadata parameter (see [OpenID Connect Discovery 1.0]), then RPs SHOULD assume that the issuer is a multi-tenant OP using a single issuer identifier and SHOULD expect the <code>tenant</code> claim to be present in ID Tokens. The <code>tenant</code> claim value MUST be one of the allowed values for the corresponding OP model as specified in the table below.<a href="#section-2.2-3.6.1" class="pilcrow">¶</a></p>
 </li>
         </ul>
-<p id="section-2.2-3">For multi-tenant OPs using tenant-specific issuer identifiers, if the <code>tenant</code> claim is present and does not match the tenant identified by the <code>iss</code> value, the RP SHOULD treat this as an error condition.<a href="#section-2.2-3" class="pilcrow">¶</a></p>
-<ul class="compact">
-<li class="compact" id="section-2.2-4.1">
-            <strong>Discovery</strong>: If an OP publishes support for the <code>tenant</code> claim in the <code>claims_supported</code> metadata parameter (see [OpenID Connect Discovery 1.0]), then RPs SHOULD assume that the issuer supports multiple tenants and SHOULD expect the <code>tenant</code> claim to be present in ID Tokens.<a href="#section-2.2-4.1" class="pilcrow">¶</a>
-</li>
-        </ul>
+<p id="section-2.2-4">The following table summarizes the <code>tenant</code> claim rules by OP model:<a href="#section-2.2-4" class="pilcrow">¶</a></p>
+<table class="center" id="table-1">
+          <caption><a href="#table-1" class="selfRef">Table 1</a></caption>
+<thead>
+            <tr>
+              <th class="text-left" rowspan="1" colspan="1">OP Model</th>
+              <th class="text-left" rowspan="1" colspan="1">Allowed Values</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">Single-tenant</td>
+              <td class="text-left" rowspan="1" colspan="1">
+                <code>personal</code> or <code>organization</code>
+</td>
+            </tr>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">Multi-tenant (single issuer)</td>
+              <td class="text-left" rowspan="1" colspan="1">
+                <code>personal</code> or unique tenant identifier</td>
+            </tr>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">Multi-tenant (tenant-specific issuers)</td>
+              <td class="text-left" rowspan="1" colspan="1">
+                <code>personal</code> or <code>organization</code>
+</td>
+            </tr>
+          </tbody>
+        </table>
 </section>
 </div>
 <div id="aud-sub">
@@ -1547,7 +1569,7 @@ the use of <em>this fixed-width font</em>.<a href="#section-1.1-2" class="pilcro
         <h3 id="name-aud_tenant">
 <a href="#section-2.4" class="section-number selfRef">2.4. </a><a href="#name-aud_tenant" class="section-name selfRef">aud_tenant</a>
         </h3>
-<p id="section-2.4-1">The <code>aud_tenant</code> claim is a JSON string that represents an RP tenant identifier. This claim is OPTIONAL and is only included when the RP is multi-tenant and the OP knows the RP tenant identifier (see Appendix A for how the RP communicates its tenant identifier to the OP).<a href="#section-2.4-1" class="pilcrow">¶</a></p>
+<p id="section-2.4-1">The <code>aud_tenant</code> claim is a JSON string that represents an RP tenant identifier. This claim is OPTIONAL and is only included when the RP is multi-tenant and the OP knows the RP tenant identifier (see <a href="#enterprise-tenancy-models">Appendix A</a> for how the RP communicates its tenant identifier to the OP).<a href="#section-2.4-1" class="pilcrow">¶</a></p>
 <p id="section-2.4-2">When the RP provides the <code>client_tenant</code> authentication request parameter, the <code>aud_tenant</code> claim value MUST be the same value that the RP provided in that parameter. When the OP determines the RP tenant identifier through other means (e.g., <code>domain_hint</code>, <code>login_hint</code>, default tenant selection, or end-user selection), the <code>aud_tenant</code> claim value MUST be a valid RP tenant identifier for the client. The value is opaque to the OP (the OP does not need to understand its semantic meaning). The value MUST be a stable identifier that is unique within the context of the <code>client_id</code> used in the authentication request, ensuring that when multiple RP tenants share the same <code>client_id</code>, each tenant can be uniquely identified.<a href="#section-2.4-2" class="pilcrow">¶</a></p>
 <p id="section-2.4-3">When <code>aud_tenant</code> is present, the <code>aud_sub</code> claim represents the identifier the RP has for the account within the context of that specific RP tenant. The combination of <code>aud</code> + <code>aud_tenant</code> and <code>aud_sub</code> MUST be unique within the RP.<a href="#section-2.4-3" class="pilcrow">¶</a></p>
 </section>
@@ -1575,11 +1597,16 @@ the use of <em>this fixed-width font</em>.<a href="#section-1.1-2" class="pilcro
 <a href="#section-3.2" class="section-number selfRef">3.2. </a><a href="#name-tenant-2" class="section-name selfRef">tenant</a>
         </h3>
 <p id="section-3.2-1">The <code>tenant</code> parameter is the explicit OP tenant identifier value that corresponds to the <code>tenant</code> claim the RP would like included in the ID Token. This parameter takes precedence over <code>domain_hint</code> when both are present.<a href="#section-3.2-1" class="pilcrow">¶</a></p>
-<p id="section-3.2-2">The <code>tenant</code> parameter value MUST match one of the following:
-- The value <code>personal</code> to indicate the RP would like the user to use an account managed by the user (personal account)
-- The value <code>organization</code> to indicate the RP would like the user to use an account managed by an organization (organizational account)
-- A stable, opaque OP tenant identifier value for multi-tenant OPs<a href="#section-3.2-2" class="pilcrow">¶</a></p>
-<p id="section-3.2-3">If the <code>tenant</code> parameter value does not match any OP tenant, the OP SHOULD return an <code>invalid_request</code> error or proceed with the authentication using the OP's default tenant selection logic. The specific behavior is implementation-dependent.<a href="#section-3.2-3" class="pilcrow">¶</a></p>
+<p id="section-3.2-2">The <code>tenant</code> parameter value MUST be one of the allowed values for the OP model as specified in the table in <a href="#tenant">Section "tenant"</a>:<a href="#section-3.2-2" class="pilcrow">¶</a></p>
+<ul class="compact">
+<li class="compact" id="section-3.2-3.1">The value <code>personal</code> to indicate the RP would like the user to use a personal account (valid for all OP models)<a href="#section-3.2-3.1" class="pilcrow">¶</a>
+</li>
+          <li class="compact" id="section-3.2-3.2">The value <code>organization</code> to indicate the RP would like the user to use an organizational account (valid for single-tenant OPs and multi-tenant OPs using tenant-specific issuers only)<a href="#section-3.2-3.2" class="pilcrow">¶</a>
+</li>
+          <li class="compact" id="section-3.2-3.3">A stable, opaque OP tenant identifier (valid for multi-tenant OPs using a single issuer only)<a href="#section-3.2-3.3" class="pilcrow">¶</a>
+</li>
+        </ul>
+<p id="section-3.2-4">If the <code>tenant</code> parameter value does not match any OP tenant, the OP SHOULD return an <code>invalid_request</code> error or proceed with the authentication using the OP's default tenant selection logic. The specific behavior is implementation-dependent.<a href="#section-3.2-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="client-tenant">
@@ -1587,7 +1614,7 @@ the use of <em>this fixed-width font</em>.<a href="#section-1.1-2" class="pilcro
         <h3 id="name-client_tenant">
 <a href="#section-3.3" class="section-number selfRef">3.3. </a><a href="#name-client_tenant" class="section-name selfRef">client_tenant</a>
         </h3>
-<p id="section-3.3-1">The <code>client_tenant</code> parameter is an OPTIONAL parameter that the RP includes to communicate its RP tenant identifier to the OP. This parameter is used when the RP is multi-tenant and uses a shared <code>client_id</code> across multiple RP tenants (see Appendix A for details on multi-tenant RP models).<a href="#section-3.3-1" class="pilcrow">¶</a></p>
+<p id="section-3.3-1">The <code>client_tenant</code> parameter is an OPTIONAL parameter that the RP includes to communicate its RP tenant identifier to the OP. This parameter is used when the RP is multi-tenant and uses a shared <code>client_id</code> across multiple RP tenants (see <a href="#enterprise-tenancy-models">Appendix A</a> for details on multi-tenant RP models).<a href="#section-3.3-1" class="pilcrow">¶</a></p>
 <p id="section-3.3-2">The client MAY register allowed tenants using the <code>tenants</code> client registration parameter. When the <code>client_tenant</code> authentication request parameter is provided, the OP SHOULD validate that the <code>client_tenant</code> value corresponds to a valid RP tenant identifier that was registered for this client.<a href="#section-3.3-2" class="pilcrow">¶</a></p>
 <p id="section-3.3-3">The <code>client_tenant</code> parameter value MUST be a stable identifier that is unique within the context of the <code>client_id</code> used in the authentication request, ensuring that when multiple RP tenants share the same <code>client_id</code>, each tenant can be uniquely identified. The value is opaque to the OP (the OP does not need to understand its semantic meaning) and MUST be echoed back in the <code>aud_tenant</code> claim.<a href="#section-3.3-3" class="pilcrow">¶</a></p>
 <p id="section-3.3-4">The OP MUST treat the <code>redirect_uri</code> as opaque and MUST NOT attempt to identify an RP tenant from a specific URL endpoint or pattern.<a href="#section-3.3-4" class="pilcrow">¶</a></p>
@@ -1688,7 +1715,7 @@ the use of <em>this fixed-width font</em>.<a href="#section-1.1-2" class="pilcro
           <h4 id="name-tenant-isolation">
 <a href="#section-6.1.1" class="section-number selfRef">6.1.1. </a><a href="#name-tenant-isolation" class="section-name selfRef">Tenant Isolation</a>
           </h4>
-<p id="section-6.1.1-1">OPs MUST ensure strict isolation between tenants. An authenticated user from one OP tenant MUST NOT be able to obtain tokens containing a different tenant's identifier. The OP MUST validate that the <code>tenant</code> claim (see Section "ID Token Claims") in issued ID Tokens accurately reflects the tenant context in which the user authenticated.<a href="#section-6.1.1-1" class="pilcrow">¶</a></p>
+<p id="section-6.1.1-1">OPs MUST ensure strict isolation between tenants. An authenticated user from one OP tenant MUST NOT be able to obtain tokens containing a different tenant's identifier. The OP MUST validate that the <code>tenant</code> claim (see <a href="#id-token-claims">Section "ID Token Claims"</a>) in issued ID Tokens accurately reflects the tenant context in which the user authenticated.<a href="#section-6.1.1-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="client-tenant-validation">
@@ -1696,7 +1723,7 @@ the use of <em>this fixed-width font</em>.<a href="#section-1.1-2" class="pilcro
           <h4 id="name-client-tenant-validation">
 <a href="#section-6.1.2" class="section-number selfRef">6.1.2. </a><a href="#name-client-tenant-validation" class="section-name selfRef">Client Tenant Validation</a>
           </h4>
-<p id="section-6.1.2-1">When the OP receives a <code>client_tenant</code> authentication request parameter (see Section "Authentication Request Parameters"), the OP SHOULD validate that the value corresponds to a registered RP tenant identifier for the given <code>client_id</code>. If the OP has registered the <code>tenants</code> client registration parameter (see Section "Client Registration Parameters") for the client, the OP SHOULD reject requests where <code>client_tenant</code> is not in the registered list.<a href="#section-6.1.2-1" class="pilcrow">¶</a></p>
+<p id="section-6.1.2-1">When the OP receives a <code>client_tenant</code> authentication request parameter (see <a href="#authentication-request-parameters">Section "Authentication Request Parameters"</a>), the OP SHOULD validate that the value corresponds to a registered RP tenant identifier for the given <code>client_id</code>. If the OP has registered the <code>tenants</code> client registration parameter (see <a href="#client-registration-parameters">Section "Client Registration Parameters"</a>) for the client, the OP SHOULD reject requests where <code>client_tenant</code> is not in the registered list.<a href="#section-6.1.2-1" class="pilcrow">¶</a></p>
 <p id="section-6.1.2-2">Failure to validate the <code>client_tenant</code> parameter could allow an attacker to request tokens for arbitrary RP tenants, potentially bypassing RP tenant-specific policies configured at the OP.<a href="#section-6.1.2-2" class="pilcrow">¶</a></p>
 </section>
 </div>
@@ -1706,8 +1733,8 @@ the use of <em>this fixed-width font</em>.<a href="#section-1.1-2" class="pilcro
 <a href="#section-6.1.3" class="section-number selfRef">6.1.3. </a><a href="#name-subject-identifier-collisio" class="section-name selfRef">Subject Identifier Collision</a>
           </h4>
 <p id="section-6.1.3-1">Multi-tenant OPs MUST ensure that subject identifiers are unambiguous across tenants to prevent account confusion where an RP incorrectly links accounts from different OP tenants.<a href="#section-6.1.3-1" class="pilcrow">¶</a></p>
-<p id="section-6.1.3-2">For multi-tenant OPs using a single issuer (see Appendix A), the OP MUST ensure that subject identifiers are unambiguous across tenants. If the same <code>sub</code> value could exist in multiple OP tenants, the OP MUST include the <code>tenant</code> claim (see Section "ID Token Claims") in the ID Token to enable RPs to correctly identify the account. The combination of <code>iss</code> + <code>tenant</code> + <code>sub</code> (for public subject identifiers) or <code>iss</code> + <code>tenant</code> + <code>client_id</code> + <code>sub</code> (for pairwise subject identifiers) MUST be unique across all tenants (see Appendix A for detailed requirements).<a href="#section-6.1.3-2" class="pilcrow">¶</a></p>
-<p id="section-6.1.3-3">For multi-tenant OPs using tenant-specific issuer identifiers (see Appendix A), the OP MUST ensure that the combination of <code>iss</code> + <code>sub</code> (for public subject identifiers) or <code>iss</code> + <code>client_id</code> + <code>sub</code> (for pairwise subject identifiers) is unique across all tenants. Since each tenant has a different issuer identifier, the OIDC Core requirement that <code>sub</code> is unique within <code>iss</code> already ensures tenant isolation. However, the OP MUST ensure uniqueness across all tenants, regardless of whether a client is shared across tenants or unique per tenant (see Appendix A for detailed requirements).<a href="#section-6.1.3-3" class="pilcrow">¶</a></p>
+<p id="section-6.1.3-2">For multi-tenant OPs using a single issuer (see <a href="#enterprise-tenancy-models">Appendix A</a>), the OP MUST ensure that subject identifiers are unambiguous across tenants. If the same <code>sub</code> value could exist in multiple OP tenants, the OP MUST include the <code>tenant</code> claim (see <a href="#id-token-claims">Section "ID Token Claims"</a>) in the ID Token to enable RPs to correctly identify the account. The combination of <code>iss</code> + <code>tenant</code> + <code>sub</code> (for public subject identifiers) or <code>iss</code> + <code>tenant</code> + <code>client_id</code> + <code>sub</code> (for pairwise subject identifiers) MUST be unique across all tenants (see <a href="#enterprise-tenancy-models">Appendix A</a> for detailed requirements).<a href="#section-6.1.3-2" class="pilcrow">¶</a></p>
+<p id="section-6.1.3-3">For multi-tenant OPs using tenant-specific issuer identifiers (see <a href="#enterprise-tenancy-models">Appendix A</a>), the OP MUST ensure that the combination of <code>iss</code> + <code>sub</code> (for public subject identifiers) or <code>iss</code> + <code>client_id</code> + <code>sub</code> (for pairwise subject identifiers) is unique across all tenants. Since each tenant has a different issuer identifier, the OIDC Core requirement that <code>sub</code> is unique within <code>iss</code> already ensures tenant isolation. However, the OP MUST ensure uniqueness across all tenants, regardless of whether a client is shared across tenants or unique per tenant (see <a href="#enterprise-tenancy-models">Appendix A</a> for detailed requirements).<a href="#section-6.1.3-3" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="token-injection-prevention">
@@ -1730,7 +1757,7 @@ the use of <em>this fixed-width font</em>.<a href="#section-1.1-2" class="pilcro
           <h4 id="name-tenant-claim-validation">
 <a href="#section-6.2.1" class="section-number selfRef">6.2.1. </a><a href="#name-tenant-claim-validation" class="section-name selfRef">Tenant Claim Validation</a>
           </h4>
-<p id="section-6.2.1-1">When an RP expects to receive the <code>tenant</code> claim (see Section "ID Token Claims") (e.g., when authenticating to a multi-tenant OP using a single issuer, as described in Appendix A), the RP MUST validate that the <code>tenant</code> claim is present in the ID Token. If the RP has prior knowledge of the expected tenant (e.g., from a previous authentication or configuration), the RP SHOULD validate that the received <code>tenant</code> claim matches the expected value.<a href="#section-6.2.1-1" class="pilcrow">¶</a></p>
+<p id="section-6.2.1-1">When an RP expects to receive the <code>tenant</code> claim (see <a href="#id-token-claims">Section "ID Token Claims"</a>) (e.g., when authenticating to a multi-tenant OP using a single issuer, as described in <a href="#enterprise-tenancy-models">Appendix A</a>), the RP MUST validate that the <code>tenant</code> claim is present in the ID Token. If the RP has prior knowledge of the expected tenant (e.g., from a previous authentication or configuration), the RP SHOULD validate that the received <code>tenant</code> claim matches the expected value.<a href="#section-6.2.1-1" class="pilcrow">¶</a></p>
 <p id="section-6.2.1-2">Failure to validate the <code>tenant</code> claim could result in:
 - Account confusion where users from different OP tenants are incorrectly linked
 - Privilege escalation if tenant-specific access controls are bypassed<a href="#section-6.2.1-2" class="pilcrow">¶</a></p>
@@ -1741,8 +1768,8 @@ the use of <em>this fixed-width font</em>.<a href="#section-1.1-2" class="pilcro
           <h4 id="name-aud_tenant-claim-validation">
 <a href="#section-6.2.2" class="section-number selfRef">6.2.2. </a><a href="#name-aud_tenant-claim-validation" class="section-name selfRef">aud_tenant Claim Validation</a>
           </h4>
-<p id="section-6.2.2-1">When an RP sends the <code>client_tenant</code> authentication request parameter (see Section "Authentication Request Parameters"), the RP MUST validate that the returned <code>aud_tenant</code> claim (see Section "ID Token Claims") matches the value sent in the request. If the <code>aud_tenant</code> claim is missing or contains a different value, the RP MUST reject the ID Token.<a href="#section-6.2.2-1" class="pilcrow">¶</a></p>
-<p id="section-6.2.2-2">This validation prevents an attacker from obtaining a token intended for one RP tenant and using it to authenticate to a different RP tenant. See Appendix A for details on how the <code>client_tenant</code> parameter relates to the <code>aud_tenant</code> claim.<a href="#section-6.2.2-2" class="pilcrow">¶</a></p>
+<p id="section-6.2.2-1">When an RP sends the <code>client_tenant</code> authentication request parameter (see <a href="#authentication-request-parameters">Section "Authentication Request Parameters"</a>), the RP MUST validate that the returned <code>aud_tenant</code> claim (see <a href="#id-token-claims">Section "ID Token Claims"</a>) matches the value sent in the request. If the <code>aud_tenant</code> claim is missing or contains a different value, the RP MUST reject the ID Token.<a href="#section-6.2.2-1" class="pilcrow">¶</a></p>
+<p id="section-6.2.2-2">This validation prevents an attacker from obtaining a token intended for one RP tenant and using it to authenticate to a different RP tenant. See <a href="#enterprise-tenancy-models">Appendix A</a> for details on how the <code>client_tenant</code> parameter relates to the <code>aud_tenant</code> claim.<a href="#section-6.2.2-2" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="account-identifier-uniqueness">
@@ -1751,9 +1778,9 @@ the use of <em>this fixed-width font</em>.<a href="#section-1.1-2" class="pilcro
 <a href="#section-6.2.3" class="section-number selfRef">6.2.3. </a><a href="#name-account-identifier-uniquene" class="section-name selfRef">Account Identifier Uniqueness</a>
           </h4>
 <p id="section-6.2.3-1">RPs MUST use the complete set of identifying claims when linking accounts:
-- For multi-tenant OPs using a single issuer (see Appendix A): <code>iss</code> + <code>tenant</code> (see Section "ID Token Claims") + <code>sub</code>
-- For multi-tenant OPs using tenant-specific issuers (see Appendix A): <code>iss</code> + <code>sub</code>
-- For multi-tenant RPs with shared <code>client_id</code> (see Appendix A): <code>aud</code> + <code>aud_tenant</code> (see Section "ID Token Claims") + <code>aud_sub</code> (see Section "ID Token Claims") (when present)<a href="#section-6.2.3-1" class="pilcrow">¶</a></p>
+- For multi-tenant OPs using a single issuer (see <a href="#enterprise-tenancy-models">Appendix A</a>): <code>iss</code> + <code>tenant</code> (see <a href="#id-token-claims">Section "ID Token Claims"</a>) + <code>sub</code>
+- For multi-tenant OPs using tenant-specific issuers (see <a href="#enterprise-tenancy-models">Appendix A</a>): <code>iss</code> + <code>sub</code>
+- For multi-tenant RPs with shared <code>client_id</code> (see <a href="#enterprise-tenancy-models">Appendix A</a>): <code>aud</code> + <code>aud_tenant</code> (see <a href="#id-token-claims">Section "ID Token Claims"</a>) + <code>aud_sub</code> (see <a href="#id-token-claims">Section "ID Token Claims"</a>) (when present)<a href="#section-6.2.3-1" class="pilcrow">¶</a></p>
 <p id="section-6.2.3-2">Using only a subset of these claims (e.g., only <code>sub</code>) could result in incorrectly linking accounts from different tenants.<a href="#section-6.2.3-2" class="pilcrow">¶</a></p>
 </section>
 </div>
@@ -1910,7 +1937,7 @@ the use of <em>this fixed-width font</em>.<a href="#section-1.1-2" class="pilcro
             <p id="appendix-A.1-5.1.1"><strong>Multi-tenant OP</strong>: The OP has multiple tenants. Multi-tenant OPs may use a single issuer identifier for all tenants, or tenant-specific issuer identifiers:<a href="#appendix-A.1-5.1.1" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="appendix-A.1-5.1.2.1">
-                <p id="appendix-A.1-5.1.2.1.1"><strong>Single issuer for all tenants</strong>: The OP uses one issuer identifier for all tenants, and the <code>tenant</code> claim (see Section "ID Token Claims") distinguishes between tenants.<a href="#appendix-A.1-5.1.2.1.1" class="pilcrow">¶</a></p>
+                <p id="appendix-A.1-5.1.2.1.1"><strong>Single issuer for all tenants</strong>: The OP uses one issuer identifier for all tenants, and the <code>tenant</code> claim (see <a href="#id-token-claims">Section "ID Token Claims"</a>) distinguishes between tenants.<a href="#appendix-A.1-5.1.2.1.1" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="appendix-A.1-5.1.2.1.2.1">
                     <p id="appendix-A.1-5.1.2.1.2.1.1"><strong>Issuer Configuration</strong>: All tenants share the same issuer identifier (<code>iss</code>), OP metadata endpoint, and signing keys.<a href="#appendix-A.1-5.1.2.1.2.1.1" class="pilcrow">¶</a></p>
@@ -1989,8 +2016,8 @@ the use of <em>this fixed-width font</em>.<a href="#section-1.1-2" class="pilcro
 </li>
         </ul>
 <p id="appendix-A.1-6">The following table summarizes OP tenancy models:<a href="#appendix-A.1-6" class="pilcrow">¶</a></p>
-<table class="center" id="table-1">
-          <caption><a href="#table-1" class="selfRef">Table 1</a></caption>
+<table class="center" id="table-2">
+          <caption><a href="#table-2" class="selfRef">Table 2</a></caption>
 <thead>
             <tr>
               <th class="text-left" rowspan="1" colspan="1">Model</th>
@@ -2015,7 +2042,7 @@ the use of <em>this fixed-width font</em>.<a href="#section-1.1-2" class="pilcro
                 <code>public</code>: <code>iss</code> + <code>tenant</code> + <code>sub</code> unique<br>
                 <code>pairwise</code>: <code>iss</code> + <code>tenant</code> + <code>client_id</code> + <code>sub</code> unique</td>
               <td class="text-left" rowspan="1" colspan="1">
-                <code>tenant</code> claim in ID Token (see Section "ID Token Claims")</td>
+                <code>tenant</code> claim in ID Token (see <a href="#id-token-claims">Section "ID Token Claims"</a>)</td>
             </tr>
             <tr>
               <td class="text-left" rowspan="1" colspan="1">Multi-tenant OP (tenant-specific issuers)</td>
@@ -2030,7 +2057,7 @@ the use of <em>this fixed-width font</em>.<a href="#section-1.1-2" class="pilcro
         </table>
 <ul class="compact">
 <li class="compact" id="appendix-A.1-8.1">
-            <strong>Discovery</strong>: If an OP publishes support for the <code>tenant</code> claim in the <code>claims_supported</code> metadata parameter (see [OpenID Connect Discovery 1.0]), then RPs SHOULD assume that the issuer supports multiple tenants and SHOULD expect the <code>tenant</code> claim to be present in ID Tokens.<a href="#appendix-A.1-8.1" class="pilcrow">¶</a>
+            <strong>Discovery</strong>: If an OP publishes support for the <code>tenant</code> claim in the <code>claims_supported</code> metadata parameter (see [OpenID Connect Discovery 1.0]), then RPs SHOULD assume that the issuer is a multi-tenant OP using a single issuer identifier and SHOULD expect the <code>tenant</code> claim to be present in ID Tokens. The <code>tenant</code> claim value MUST be one of the allowed values for the corresponding OP model as specified in the table in <a href="#tenant">Section "tenant"</a>.<a href="#appendix-A.1-8.1" class="pilcrow">¶</a>
 </li>
         </ul>
 </section>
@@ -2044,10 +2071,10 @@ the use of <em>this fixed-width font</em>.<a href="#section-1.1-2" class="pilcro
 <p id="appendix-A.2-2">The following applies only to multi-tenant OPs that use a single issuer for all tenants. For such OPs, the RP MAY specify which OP tenant it wants the user to authenticate to using one of the following mechanisms:<a href="#appendix-A.2-2" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="appendix-A.2-3.1">
-            <p id="appendix-A.2-3.1.1"><strong><code>tenant</code> parameter</strong>: The RP includes the <code>tenant</code> parameter in the authentication request with the OP tenant identifier value (e.g., <code>tenant=acme-corp</code>). When the OP receives this parameter, it SHOULD include the <code>tenant</code> claim in the ID Token with the same value. This is RECOMMENDED for RPs that know which <code>tenant</code> to make an authentication request to. See Section "Authentication Request Parameters" for details.<a href="#appendix-A.2-3.1.1" class="pilcrow">¶</a></p>
+            <p id="appendix-A.2-3.1.1"><strong><code>tenant</code> parameter</strong>: The RP includes the <code>tenant</code> parameter in the authentication request with the OP tenant identifier value (e.g., <code>tenant=acme-corp</code>). When the OP receives this parameter, it SHOULD include the <code>tenant</code> claim in the ID Token with the same value. This is RECOMMENDED for RPs that know which <code>tenant</code> to make an authentication request to. See <a href="#authentication-request-parameters">Section "Authentication Request Parameters"</a> for details.<a href="#appendix-A.2-3.1.1" class="pilcrow">¶</a></p>
 </li>
           <li class="normal" id="appendix-A.2-3.2">
-            <p id="appendix-A.2-3.2.1"><strong><code>domain_hint</code> parameter</strong>: The RP includes the <code>domain_hint</code> parameter with a domain name or email domain (e.g., <code>example.com</code>) that helps the OP identify the appropriate tenant. This is a user experience hint and is not guaranteed to uniquely identify a tenant. When both <code>tenant</code> and <code>domain_hint</code> are present, the <code>tenant</code> parameter takes precedence. If the OP cannot uniquely identify the tenant from <code>domain_hint</code> alone, the OP's tenant selection behavior is implementation-dependent. See Section "Authentication Request Parameters" for details.<a href="#appendix-A.2-3.2.1" class="pilcrow">¶</a></p>
+            <p id="appendix-A.2-3.2.1"><strong><code>domain_hint</code> parameter</strong>: The RP includes the <code>domain_hint</code> parameter with a domain name or email domain (e.g., <code>example.com</code>) that helps the OP identify the appropriate tenant. This is a user experience hint and is not guaranteed to uniquely identify a tenant. When both <code>tenant</code> and <code>domain_hint</code> are present, the <code>tenant</code> parameter takes precedence. If the OP cannot uniquely identify the tenant from <code>domain_hint</code> alone, the OP's tenant selection behavior is implementation-dependent. See <a href="#authentication-request-parameters">Section "Authentication Request Parameters"</a> for details.<a href="#appendix-A.2-3.2.1" class="pilcrow">¶</a></p>
 </li>
         </ul>
 <p id="appendix-A.2-4">When the OP tenant is not specified by the RP (neither <code>tenant</code> nor <code>domain_hint</code> is provided, or <code>domain_hint</code> does not uniquely identify a tenant), the OP MAY:
@@ -2168,7 +2195,7 @@ the use of <em>this fixed-width font</em>.<a href="#section-1.1-2" class="pilcro
                 <p id="appendix-A.3-5.1.5.2.1"><strong>Shared Client for all Tenants</strong>: Multiple RP tenants share a single <code>client_id</code> registered with the OP.<a href="#appendix-A.3-5.1.5.2.1" class="pilcrow">¶</a></p>
 <ul class="compact normal">
 <li class="compact normal" id="appendix-A.3-5.1.5.2.2.1">
-                    <strong>Registration</strong>: All RP tenants share a single <code>client_id</code> registered with the OP. The RP MAY register the <code>tenants</code> client registration parameter (see Section "Client Registration Parameters") as a JSON array of strings containing the RP tenant identifiers.<a href="#appendix-A.3-5.1.5.2.2.1" class="pilcrow">¶</a>
+                    <strong>Registration</strong>: All RP tenants share a single <code>client_id</code> registered with the OP. The RP MAY register the <code>tenants</code> client registration parameter (see <a href="#client-registration-parameters">Section "Client Registration Parameters"</a>) as a JSON array of strings containing the RP tenant identifiers.<a href="#appendix-A.3-5.1.5.2.2.1" class="pilcrow">¶</a>
 </li>
                   <li class="compact normal" id="appendix-A.3-5.1.5.2.2.2">
                     <strong>Account Identifier Uniqueness</strong>: When both <code>aud_tenant</code> and <code>aud_sub</code> are present, their combination MUST be unique for a given <code>aud</code> (client identifier) within the RP. This ensures that account identifiers are unambiguous within the context of the RP, even when the same <code>aud_sub</code> value might exist in different RP tenants.<a href="#appendix-A.3-5.1.5.2.2.2" class="pilcrow">¶</a>
@@ -2204,8 +2231,8 @@ the use of <em>this fixed-width font</em>.<a href="#section-1.1-2" class="pilcro
 </li>
         </ul>
 <p id="appendix-A.3-6">The following table summarizes RP tenancy models:<a href="#appendix-A.3-6" class="pilcrow">¶</a></p>
-<table class="center" id="table-2">
-          <caption><a href="#table-2" class="selfRef">Table 2</a></caption>
+<table class="center" id="table-3">
+          <caption><a href="#table-3" class="selfRef">Table 3</a></caption>
 <thead>
             <tr>
               <th class="text-left" rowspan="1" colspan="1">Model</th>
@@ -2239,7 +2266,7 @@ the use of <em>this fixed-width font</em>.<a href="#section-1.1-2" class="pilcro
                 <code>aud_tenant</code> + <code>aud_sub</code> unique within <code>aud</code>
 </td>
               <td class="text-left" rowspan="1" colspan="1">
-                <code>aud</code> + <code>aud_tenant</code> claim in ID Token (see Section "ID Token Claims")</td>
+                <code>aud</code> + <code>aud_tenant</code> claim in ID Token (see <a href="#id-token-claims">Section "ID Token Claims"</a>)</td>
             </tr>
           </tbody>
         </table>
@@ -2255,11 +2282,11 @@ the use of <em>this fixed-width font</em>.<a href="#section-1.1-2" class="pilcro
         <h3 id="name-rp-tenant-communication">
 <a href="#appendix-A.4" class="section-number selfRef">A.4. </a><a href="#name-rp-tenant-communication" class="section-name selfRef">RP Tenant Communication</a>
         </h3>
-<p id="appendix-A.4-1">When an RP is multi-tenant and uses a shared <code>client_id</code>, the RP MAY communicate its tenant identifier to the OP, but is not required to do so. If the OP knows the RP tenant identifier, it SHOULD include it in the <code>aud_tenant</code> claim of the ID Token (see Section "ID Token Claims").<a href="#appendix-A.4-1" class="pilcrow">¶</a></p>
+<p id="appendix-A.4-1">When an RP is multi-tenant and uses a shared <code>client_id</code>, the RP MAY communicate its tenant identifier to the OP, but is not required to do so. If the OP knows the RP tenant identifier, it SHOULD include it in the <code>aud_tenant</code> claim of the ID Token (see <a href="#id-token-claims">Section "ID Token Claims"</a>).<a href="#appendix-A.4-1" class="pilcrow">¶</a></p>
 <p id="appendix-A.4-2">The RP can communicate its tenant identifier using one of the following mechanisms:<a href="#appendix-A.4-2" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="appendix-A.4-3.1">
-            <p id="appendix-A.4-3.1.1"><strong><code>client_tenant</code> authentication request parameter</strong> (RECOMMENDED): The RP includes the <code>client_tenant</code> parameter in the authentication request with its tenant identifier value. This is explicit and unambiguous, allowing the OP to include the <code>aud_tenant</code> claim in the ID Token and apply RP tenant-specific policies (e.g., access control, consent requirements, authentication methods). When present, the OP MUST echo this value back in the <code>aud_tenant</code> claim. See Section "Authentication Request Parameters" for details.<a href="#appendix-A.4-3.1.1" class="pilcrow">¶</a></p>
+            <p id="appendix-A.4-3.1.1"><strong><code>client_tenant</code> authentication request parameter</strong> (RECOMMENDED): The RP includes the <code>client_tenant</code> parameter in the authentication request with its tenant identifier value. This is explicit and unambiguous, allowing the OP to include the <code>aud_tenant</code> claim in the ID Token and apply RP tenant-specific policies (e.g., access control, consent requirements, authentication methods). When present, the OP MUST echo this value back in the <code>aud_tenant</code> claim. See <a href="#authentication-request-parameters">Section "Authentication Request Parameters"</a> for details.<a href="#appendix-A.4-3.1.1" class="pilcrow">¶</a></p>
 </li>
           <li class="normal" id="appendix-A.4-3.2">
             <p id="appendix-A.4-3.2.1"><strong><code>state</code> parameter or session context</strong>: RPs may include tenant identification information in the opaque <code>state</code> parameter of the OpenID Connect Authentication Request, or maintain tenant context via cookies or other session mechanisms. When the RP uses only this mechanism, the OP does not have access to the tenant identifier and MUST omit the <code>aud_tenant</code> claim from the ID Token. The OP cannot apply RP tenant-specific policies, and the RP MUST use implementation-specific mechanisms (such as parsing the <code>state</code> parameter or session context) to determine the tenant for routing the authentication response. This pattern is commonly used in practice.<a href="#appendix-A.4-3.2.1" class="pilcrow">¶</a></p>

--- a/openid-connect-enterprise-extensions-1_0.html
+++ b/openid-connect-enterprise-extensions-1_0.html
@@ -1,0 +1,2428 @@
+<!DOCTYPE html>
+<html lang="en" class="Internet-Draft">
+<head>
+<meta charset="utf-8">
+<meta content="Common,Latin" name="scripts">
+<meta content="initial-scale=1.0" name="viewport">
+<title>OpenID Connect Enterprise Extensions 1.0 - draft 02</title>
+<meta content="Dick Hardt" name="author">
+<meta content="Karl McGuinness" name="author">
+<meta content="
+       OpenID Connect 1.0 has become a popular choice for single sign-on in enterprise use cases. To improve interoperability, OpenID Connect Enterprise Extensions specifies a number of common or desirable extensions to OpenID Connect. 
+    " name="description">
+<meta content="xml2rfc 3.31.0" name="generator">
+<meta content="security" name="keyword">
+<meta content="openid" name="keyword">
+<meta content="enterprise" name="keyword">
+<meta content="openid-connect-enterprise-extensions-1_0" name="ietf.draft">
+<!-- Generator version information:
+  xml2rfc 3.31.0
+    Python 3.14.2
+    ConfigArgParse 1.7.1
+    google-i18n-address 3.1.1
+    intervaltree 3.1.0
+    Jinja2 3.1.6
+    lxml 6.0.2
+    platformdirs 4.5.1
+    pycountry 24.6.1
+    PyYAML 6.0.3
+    requests 2.32.5
+    wcwidth 0.2.14
+-->
+<link href="openid-connect-enterprise-extensions-1_0.xml" rel="alternate" type="application/rfc+xml">
+<link href="#copyright" rel="license">
+<style type="text/css">/*
+
+  NOTE: Changes at the bottom of this file overrides some earlier settings.
+
+  Once the style has stabilized and has been adopted as an official RFC style,
+  this can be consolidated so that style settings occur only in one place, but
+  for now the contents of this file consists first of the initial CSS work as
+  provided to the RFC Formatter (xml2rfc) work, followed by itemized and
+  commented changes found necessary during the development of the v3
+  formatters.
+
+*/
+
+/* fonts */
+@import url('https://static.ietf.org/fonts/noto-sans/import.css'); /* Sans-serif */
+@import url('https://static.ietf.org/fonts/noto-serif/import.css'); /* Serif (print) */
+@import url('https://static.ietf.org/fonts/roboto-mono/import.css'); /* Monospace */
+
+:root {
+  --font-sans: 'Noto Sans', Arial, Helvetica, sans-serif;
+  --font-serif: 'Noto Serif', 'Times', 'Times New Roman', serif;
+  --font-mono: 'Roboto Mono', Courier, 'Courier New', monospace;
+}
+
+@viewport {
+  zoom: 1.0;
+}
+@-ms-viewport {
+  width: extend-to-zoom;
+  zoom: 1.0;
+}
+/* general and mobile first */
+html {
+}
+body {
+  max-width: 90%;
+  margin: 1.5em auto;
+  color: #222;
+  background-color: #fff;
+  font-size: 14px;
+  font-family: var(--font-sans);
+  line-height: 1.6;
+  scroll-behavior: smooth;
+  overflow-wrap: break-word;
+}
+.ears {
+  display: none;
+}
+
+/* headings */
+#title, h1, h2, h3, h4, h5, h6 {
+  margin: 1em 0 0.5em;
+  font-weight: bold;
+  line-height: 1.3;
+}
+#title {
+  clear: both;
+  border-bottom: 1px solid #ddd;
+  margin: 0 0 0.5em 0;
+  padding: 1em 0 0.5em;
+}
+.author {
+  padding-bottom: 4px;
+}
+h1 {
+  font-size: 26px;
+  margin: 1em 0;
+}
+h2 {
+  font-size: 22px;
+  margin-top: -20px;  /* provide offset for in-page anchors */
+  padding-top: 33px;
+}
+h3 {
+  font-size: 18px;
+  margin-top: -36px;  /* provide offset for in-page anchors */
+  padding-top: 42px;
+}
+h4 {
+  font-size: 16px;
+  margin-top: -36px;  /* provide offset for in-page anchors */
+  padding-top: 42px;
+}
+h5, h6 {
+  font-size: 14px;
+}
+#n-copyright-notice {
+  border-bottom: 1px solid #ddd;
+  padding-bottom: 1em;
+  margin-bottom: 1em;
+}
+/* general structure */
+p {
+  padding: 0;
+  margin: 0 0 1em 0;
+  text-align: left;
+}
+div, span {
+  position: relative;
+}
+div {
+  margin: 0;
+}
+.alignRight.art-text {
+  background-color: #f9f9f9;
+  border: 1px solid #eee;
+  border-radius: 3px;
+  padding: 1em 1em 0;
+  margin-bottom: 1.5em;
+}
+.alignRight.art-text pre {
+  padding: 0;
+}
+.alignRight {
+  margin: 1em 0;
+}
+.alignRight > *:first-child {
+  border: none;
+  margin: 0;
+  float: right;
+  clear: both;
+}
+.alignRight > *:nth-child(2) {
+  clear: both;
+  display: block;
+  border: none;
+}
+svg {
+  display: block;
+}
+@media print {
+  svg {
+    max-height: 850px;
+    max-width: 660px;
+  }
+}
+svg[font-family~="serif" i], svg [font-family~="serif" i] {
+  font-family: var(--font-serif);
+}
+svg[font-family~="sans-serif" i], svg [font-family~="sans-serif" i] {
+  font-family: var(--font-sans);
+}
+svg[font-family~="monospace" i], svg [font-family~="monospace" i] {
+  font-family: var(--font-mono);
+}
+.alignCenter.art-text {
+  background-color: #f9f9f9;
+  border: 1px solid #eee;
+  border-radius: 3px;
+  padding: 1em 1em 0;
+  margin-bottom: 1.5em;
+}
+.alignCenter.art-text pre {
+  padding: 0;
+}
+.alignCenter {
+  margin: 1em 0;
+}
+.alignCenter > *:first-child {
+  display: table;
+  border: none;
+  margin: 0 auto;
+}
+
+/* lists */
+ol, ul {
+  padding: 0;
+  margin: 0 0 1em 2em;
+}
+ol ol, ul ul, ol ul, ul ol {
+  margin-left: 1em;
+}
+li {
+  margin: 0 0 0.25em 0;
+}
+.ulCompact li {
+  margin: 0;
+}
+ul.empty, .ulEmpty {
+  list-style-type: none;
+}
+ul.empty li, .ulEmpty li {
+  margin-top: 0.5em;
+}
+ul.ulBare, li.ulBare {
+  margin-left: 0em !important;
+}
+ul.compact, .ulCompact,
+ol.compact, .olCompact {
+  line-height: 100%;
+  margin: 0 0 0 2em;
+}
+
+/* definition lists */
+dl {
+}
+dl > dt {
+  float: left;
+  margin-right: 1em;
+}
+/* 
+dl.nohang > dt {
+  float: none;
+}
+*/
+dl > dd {
+  margin-bottom: .8em;
+  min-height: 1.3em;
+}
+dl.compact > dd, .dlCompact > dd {
+  margin-bottom: 0em;
+}
+dl > dd > dl {
+  margin-top: 0.5em;
+  margin-bottom: 0em;
+}
+
+/* links */
+a {
+  text-decoration: none;
+}
+a[href] {
+  color: #22e; /* Arlen: WCAG 2019 */
+}
+a[href]:hover {
+  background-color: #f2f2f2;
+}
+figcaption a[href],
+a[href].selfRef {
+  color: #222;
+}
+/* XXX probably not this:
+a.selfRef:hover {
+  background-color: transparent;
+  cursor: default;
+} */
+
+/* Figures */
+tt, code, pre {
+  background-color: #f9f9f9;
+  font-family: var(--font-mono);
+}
+pre {
+  border: 1px solid #eee;
+  margin: 0;
+  padding: 1em;
+}
+img {
+  max-width: 100%;
+}
+figure {
+  margin: 0;
+}
+figure blockquote {
+  margin: 0.8em 0.4em 0.4em;
+}
+figcaption {
+  font-style: italic;
+  margin: 0 0 1em 0;
+}
+@media screen {
+  pre {
+    overflow-x: auto;
+    max-width: 100%;
+    max-width: calc(100% - 22px);
+  }
+}
+
+/* aside, blockquote */
+aside, blockquote {
+  margin-left: 0;
+  padding: 1.2em 2em;
+}
+blockquote {
+  background-color: #f9f9f9;
+  color: #111; /* Arlen: WCAG 2019 */
+  border: 1px solid #ddd;
+  border-radius: 3px;
+  margin: 1em 0;
+}
+blockquote > *:last-child {
+  margin-bottom: 0;
+}
+cite {
+  display: block;
+  text-align: right;
+  font-style: italic;
+}
+.xref {
+  overflow-wrap: normal;
+}
+
+/* tables */
+table {
+  width: 100%;
+  margin: 0 0 1em;
+  border-collapse: collapse;
+  border: 1px solid #eee;
+}
+th, td {
+  text-align: left;
+  vertical-align: top;
+  padding: 0.5em 0.75em;
+}
+th {
+  text-align: left;
+  background-color: #e9e9e9;
+}
+tr:nth-child(2n+1) > td {
+  background-color: #f5f5f5;
+}
+table caption {
+  font-style: italic;
+  margin: 0;
+  padding: 0;
+  text-align: left;
+}
+table p {
+  /* XXX to avoid bottom margin on table row signifiers. If paragraphs should
+     be allowed within tables more generally, it would be far better to select on a class. */
+  margin: 0;
+}
+
+/* pilcrow */
+a.pilcrow {
+  color: #666; /* Arlen: AHDJ 2019 */
+  text-decoration: none;
+  visibility: hidden;
+  user-select: none;
+  -ms-user-select: none;
+  -o-user-select:none;
+  -moz-user-select: none;
+  -khtml-user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
+}
+@media screen {
+  aside:hover > a.pilcrow,
+  p:hover > a.pilcrow,
+  blockquote:hover > a.pilcrow,
+  div:hover > a.pilcrow,
+  li:hover > a.pilcrow,
+  pre:hover > a.pilcrow {
+    visibility: visible;
+  }
+  a.pilcrow:hover {
+    background-color: transparent;
+  }
+}
+
+/* misc */
+hr {
+  border: 0;
+  border-top: 1px solid #eee;
+}
+.bcp14 {
+  font-variant: small-caps;
+}
+
+.role {
+  font-variant: all-small-caps;
+}
+
+/* info block */
+#identifiers {
+  margin: 0;
+  font-size: 0.9em;
+}
+#identifiers dt {
+  width: 3em;
+  clear: left;
+}
+#identifiers dd {
+  float: left;
+  margin-bottom: 0;
+}
+/* Fix PDF info block run off issue */
+@media print {
+  #identifiers dd {
+    max-width: 100%;
+  }
+}
+#identifiers .authors .author {
+  display: inline-block;
+  margin-right: 1.5em;
+}
+#identifiers .authors .org {
+  font-style: italic;
+}
+
+/* The prepared/rendered info at the very bottom of the page */
+.docInfo {
+  color: #666; /* Arlen: WCAG 2019 */
+  font-size: 0.9em;
+  font-style: italic;
+  margin-top: 2em;
+}
+.docInfo .prepared {
+  float: left;
+}
+.docInfo .prepared {
+  float: right;
+}
+
+/* table of contents */
+#toc  {
+  padding: 0.75em 0 2em 0;
+  margin-bottom: 1em;
+}
+nav.toc ul {
+  margin: 0 0.5em 0 0;
+  padding: 0;
+  list-style: none;
+}
+nav.toc li {
+  line-height: 1.3em;
+  margin: 0.75em 0;
+  padding-left: 1.2em;
+  text-indent: -1.2em;
+}
+/* references */
+.references dt {
+  text-align: right;
+  font-weight: bold;
+  min-width: 7em;
+}
+.references dd {
+  margin-left: 8em;
+  overflow: auto;
+}
+
+.refInstance {
+  margin-bottom: 1.25em;
+}
+
+.refSubseries {
+  margin-bottom: 1.25em;
+}
+
+.references .ascii {
+  margin-bottom: 0.25em;
+}
+
+/* index */
+.index ul {
+  margin: 0 0 0 1em;
+  padding: 0;
+  list-style: none;
+}
+.index ul ul {
+  margin: 0;
+}
+.index li {
+  margin: 0;
+  text-indent: -2em;
+  padding-left: 2em;
+  padding-bottom: 5px;
+}
+.indexIndex {
+  margin: 0.5em 0 1em;
+}
+.index a {
+  font-weight: 700;
+}
+/* make the index two-column on all but the smallest screens */
+@media (min-width: 600px) {
+  .index ul {
+    -moz-column-count: 2;
+    -moz-column-gap: 20px;
+  }
+  .index ul ul {
+    -moz-column-count: 1;
+    -moz-column-gap: 0;
+  }
+}
+
+/* authors */
+address.vcard {
+  font-style: normal;
+  margin: 1em 0;
+}
+
+address.vcard .nameRole {
+  font-weight: 700;
+  margin-left: 0;
+}
+address.vcard .label {
+  font-family: var(--font-sans);
+  margin: 0.5em 0;
+}
+address.vcard .type {
+  display: none;
+}
+.alternative-contact {
+  margin: 1.5em 0 1em;
+}
+hr.addr {
+  border-top: 1px dashed;
+  margin: 0;
+  color: #ddd;
+  max-width: calc(100% - 16px);
+}
+
+/* temporary notes */
+.rfcEditorRemove::before {
+  position: absolute;
+  top: 0.2em;
+  right: 0.2em;
+  padding: 0.2em;
+  content: "The RFC Editor will remove this note";
+  color: #9e2a00; /* Arlen: WCAG 2019 */
+  background-color: #ffd; /* Arlen: WCAG 2019 */
+}
+.rfcEditorRemove {
+  position: relative;
+  padding-top: 1.8em;
+  background-color: #ffd; /* Arlen: WCAG 2019 */
+  border-radius: 3px;
+}
+.cref {
+  background-color: #ffd; /* Arlen: WCAG 2019 */
+  padding: 2px 4px;
+}
+.crefSource {
+  font-style: italic;
+}
+/* alternative layout for smaller screens */
+@media screen and (max-width: 1023px) {
+  body {
+    padding-top: 2em;
+  }
+  #title {
+    padding: 1em 0;
+  }
+  h1 {
+    font-size: 24px;
+  }
+  h2 {
+    font-size: 20px;
+    margin-top: -18px;  /* provide offset for in-page anchors */
+    padding-top: 38px;
+  }
+  #identifiers dd {
+    max-width: 60%;
+  }
+  #toc {
+    position: fixed;
+    z-index: 2;
+    top: 0;
+    right: 0;
+    padding: 0;
+    margin: 0;
+    background-color: inherit;
+    border-bottom: 1px solid #ccc;
+  }
+  #toc h2 {
+    margin: -1px 0 0 0;
+    padding: 4px 0 4px 6px;
+    padding-right: 1em;
+    min-width: 190px;
+    font-size: 1.1em;
+    text-align: right;
+    background-color: #444;
+    color: white;
+    cursor: pointer;
+  }
+  #toc h2::before { /* css hamburger */
+    float: right;
+    position: relative;
+    width: 1em;
+    height: 1px;
+    left: -164px;
+    margin: 6px 0 0 0;
+    background: white none repeat scroll 0 0;
+    box-shadow: 0 4px 0 0 white, 0 8px 0 0 white;
+    content: "";
+  }
+  #toc nav {
+    display: none;
+    padding: 0.5em 1em 1em;
+    overflow: auto;
+    height: calc(100vh - 48px);
+    border-left: 1px solid #ddd;
+  }
+}
+
+/* alternative layout for wide screens */
+@media screen and (min-width: 1024px) {
+  body {
+    max-width: 724px;
+    margin: 42px auto;
+    padding-left: 1.5em;
+    padding-right: 29em;
+  }
+  #toc {
+    position: fixed;
+    top: 42px;
+    right: 42px;
+    width: 25%;
+    margin: 0;
+    padding: 0 1em;
+    z-index: 1;
+  }
+  #toc h2 {
+    border-top: none;
+    border-bottom: 1px solid #ddd;
+    font-size: 1em;
+    font-weight: normal;
+    margin: 0;
+    padding: 0.25em 1em 1em 0;
+  }
+  #toc nav {
+    display: block;
+    height: calc(90vh - 84px);
+    bottom: 0;
+    padding: 0.5em 0 0;
+    overflow: auto;
+  }
+  img { /* future proofing */
+    max-width: 100%;
+    height: auto;
+  }
+}
+
+/* pagination */
+@media print {
+  body {
+    width: 100%;
+  }
+  p {
+    orphans: 3;
+    widows: 3;
+  }
+  #n-copyright-notice {
+    border-bottom: none;
+  }
+  #toc, #n-introduction {
+    page-break-before: always;
+  }
+  #toc {
+    border-top: none;
+    padding-top: 0;
+  }
+  figure, pre {
+    page-break-inside: avoid;
+  }
+  figure {
+    overflow: scroll;
+  }
+  .breakable pre {
+    break-inside: auto;
+  }
+  h1, h2, h3, h4, h5, h6 {
+    page-break-after: avoid;
+  }
+  h2+*, h3+*, h4+*, h5+*, h6+* {
+    page-break-before: avoid;
+  }
+  pre {
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    font-size: 10pt;
+  }
+  table {
+    border: 1px solid #ddd;
+  }
+  td {
+    border-top: 1px solid #ddd;
+  }
+}
+
+/* This is commented out here, as the string-set: doesn't
+   pass W3C validation currently */
+/*
+.ears thead .left {
+  string-set: ears-top-left content();
+}
+
+.ears thead .center {
+  string-set: ears-top-center content();
+}
+
+.ears thead .right {
+  string-set: ears-top-right content();
+}
+
+.ears tfoot .left {
+  string-set: ears-bottom-left content();
+}
+
+.ears tfoot .center {
+  string-set: ears-bottom-center content();
+}
+
+.ears tfoot .right {
+  string-set: ears-bottom-right content();
+}
+*/
+
+@page :first {
+  padding-top: 0;
+  @top-left {
+    content: normal;
+    border: none;
+  }
+  @top-center {
+    content: normal;
+    border: none;
+  }
+  @top-right {
+    content: normal;
+    border: none;
+  }
+}
+
+@page {
+  size: A4;
+  margin-bottom: 45mm;
+  padding-top: 20px;
+  /* The following is commented out here, but set appropriately by in code, as
+     the content depends on the document */
+  /*
+  @top-left {
+    content: 'Internet-Draft';
+    vertical-align: bottom;
+    border-bottom: solid 1px #ccc;
+  }
+  @top-left {
+    content: string(ears-top-left);
+    vertical-align: bottom;
+    border-bottom: solid 1px #ccc;
+  }
+  @top-center {
+    content: string(ears-top-center);
+    vertical-align: bottom;
+    border-bottom: solid 1px #ccc;
+  }
+  @top-right {
+    content: string(ears-top-right);
+    vertical-align: bottom;
+    border-bottom: solid 1px #ccc;
+  }
+  @bottom-left {
+    content: string(ears-bottom-left);
+    vertical-align: top;
+    border-top: solid 1px #ccc;
+  }
+  @bottom-center {
+    content: string(ears-bottom-center);
+    vertical-align: top;
+    border-top: solid 1px #ccc;
+  }
+  @bottom-right {
+      content: '[Page ' counter(page) ']';
+      vertical-align: top;
+      border-top: solid 1px #ccc;
+  }
+  */
+
+}
+
+/* Changes introduced to fix issues found during implementation */
+/* Make sure links are clickable even if overlapped by following H* */
+a {
+  z-index: 2;
+}
+/* Separate body from document info even without intervening H1 */
+section {
+  clear: both;
+}
+
+
+/* Top align author divs, to avoid names without organization dropping level with org names */
+.author {
+  vertical-align: top;
+}
+
+/* Leave room in document info to show Internet-Draft on one line */
+#identifiers dt {
+  width: 8em;
+}
+
+/* Don't waste quite as much whitespace between label and value in doc info */
+#identifiers dd {
+  margin-left: 1em;
+}
+
+/* Give floating toc a background color (needed when it's a div inside section */
+#toc {
+  background-color: white;
+}
+
+/* Make the collapsed ToC header render white on gray also when it's a link */
+@media screen and (max-width: 1023px) {
+  #toc h2 a,
+  #toc h2 a:link,
+  #toc h2 a:focus,
+  #toc h2 a:hover,
+  #toc a.toplink,
+  #toc a.toplink:hover {
+    color: white;
+    background-color: #444;
+    text-decoration: none;
+  }
+}
+
+/* Give the bottom of the ToC some whitespace */
+@media screen and (min-width: 1024px) {
+  #toc {
+    padding: 0 0 1em 1em;
+  }
+}
+
+/* Style section numbers with more space between number and title */
+.section-number {
+  padding-right: 0.5em;
+}
+
+/* prevent monospace from becoming overly large */
+tt, code, pre {
+  font-size: 95%;
+}
+
+/* Fix the height/width aspect for ascii art*/
+.sourcecode pre,
+.art-text pre {
+  line-height: 1.12;
+}
+
+
+/* Add styling for a link in the ToC that points to the top of the document */
+a.toplink {
+  float: right;
+  margin-right: 0.5em;
+}
+
+/* Fix the dl styling to match the RFC 7992 attributes */
+dl > dt,
+dl.dlParallel > dt {
+  float: left;
+  margin-right: 1em;
+}
+dl.dlNewline > dt {
+  float: none;
+}
+
+/* Provide styling for table cell text alignment */
+table td.text-left,
+table th.text-left {
+  text-align: left;
+}
+table td.text-center,
+table th.text-center {
+  text-align: center;
+}
+table td.text-right,
+table th.text-right {
+  text-align: right;
+}
+
+/* Make the alternative author contact information look less like just another
+   author, and group it closer with the primary author contact information */
+.alternative-contact {
+  margin: 0.5em 0 0.25em 0;
+}
+address .non-ascii {
+  margin: 0 0 0 2em;
+}
+
+/* With it being possible to set tables with alignment
+  left, center, and right, { width: 100%; } does not make sense */
+table {
+  width: auto;
+}
+
+/* Avoid reference text that sits in a block with very wide left margin,
+   because of a long floating dt label.*/
+.references dd {
+  overflow: visible;
+}
+
+/* Control caption placement */
+caption {
+  caption-side: bottom;
+}
+
+/* Limit the width of the author address vcard, so names in right-to-left
+   script don't end up on the other side of the page. */
+
+address.vcard {
+  max-width: 30em;
+  margin-right: auto;
+}
+
+/* For address alignment dependent on LTR or RTL scripts */
+address div.left {
+  text-align: left;
+}
+address div.right {
+  text-align: right;
+}
+
+/* Provide table alignment support.  We can't use the alignX classes above
+   since they do unwanted things with caption and other styling. */
+table.right {
+ margin-left: auto;
+ margin-right: 0;
+}
+table.center {
+ margin-left: auto;
+ margin-right: auto;
+}
+table.left {
+ margin-left: 0;
+ margin-right: auto;
+}
+
+/* Give the table caption label the same styling as the figcaption */
+caption a[href] {
+  color: #222;
+}
+
+@media print {
+  .toplink {
+    display: none;
+  }
+
+  /* avoid overwriting the top border line with the ToC header */
+  #toc {
+    padding-top: 1px;
+  }
+
+  /* Avoid page breaks inside dl and author address entries */
+  .vcard {
+    page-break-inside: avoid;
+  }
+
+}
+/* Tweak the bcp14 keyword presentation */
+.bcp14 {
+  font-variant: small-caps;
+  font-weight: bold;
+  font-size: 0.9em;
+}
+/* Tweak the invisible space above H* in order not to overlay links in text above */
+ h2 {
+  margin-top: -18px;  /* provide offset for in-page anchors */
+  padding-top: 31px;
+ }
+ h3 {
+  margin-top: -18px;  /* provide offset for in-page anchors */
+  padding-top: 24px;
+ }
+ h4 {
+  margin-top: -18px;  /* provide offset for in-page anchors */
+  padding-top: 24px;
+ }
+/* Float artwork pilcrow to the right */
+@media screen {
+  .artwork a.pilcrow {
+    display: block;
+    line-height: 0.7;
+    margin-top: 0.15em;
+  }
+}
+/* Make pilcrows on dd visible */
+@media screen {
+  dd:hover > a.pilcrow {
+    visibility: visible;
+  }
+}
+/* Make the placement of figcaption match that of a table's caption
+   by removing the figure's added bottom margin */
+.alignLeft.art-text,
+.alignCenter.art-text,
+.alignRight.art-text {
+   margin-bottom: 0;
+}
+.alignLeft,
+.alignCenter,
+.alignRight {
+  margin: 1em 0 0 0;
+}
+/* In print, the pilcrow won't show on hover, so prevent it from taking up space,
+   possibly even requiring a new line */
+@media print {
+  a.pilcrow {
+    display: none;
+  }
+}
+/* Styling for the external metadata */
+div#external-metadata {
+  background-color: #eee;
+  padding: 0.5em;
+  margin-bottom: 0.5em;
+  display: none;
+}
+div#internal-metadata {
+  padding: 0.5em;                       /* to match the external-metadata padding */
+}
+/* Styling for title RFC Number */
+h1#rfcnum {
+  clear: both;
+  margin: 0 0 -1em;
+  padding: 1em 0 0 0;
+}
+/* Make .olPercent look the same as <ol><li> */
+dl.olPercent > dd {
+  margin-bottom: 0.25em;
+  min-height: initial;
+}
+/* Give aside some styling to set it apart */
+aside {
+  border-left: 1px solid #ddd;
+  margin: 1em 0 1em 2em;
+  padding: 0.2em 2em;
+}
+aside > dl,
+aside > ol,
+aside > ul,
+aside > table,
+aside > p {
+  margin-bottom: 0.5em;
+}
+/* Additional page break settings */
+@media print {
+  figcaption, table caption {
+    page-break-before: avoid;
+  }
+}
+/* Font size adjustments for print */
+@media print {
+  body  { font-size: 10pt;      line-height: normal; max-width: 96%; }
+  h1    { font-size: 1.72em;    padding-top: 1.5em; } /* 1*1.2*1.2*1.2 */
+  h2    { font-size: 1.44em;    padding-top: 1.5em; } /* 1*1.2*1.2 */
+  h3    { font-size: 1.2em;     padding-top: 1.5em; } /* 1*1.2 */
+  h4    { font-size: 1em;       padding-top: 1.5em; }
+  h5, h6 { font-size: 1em;      margin: initial; padding: 0.5em 0 0.3em; }
+}
+/* Sourcecode margin in print, when there's no pilcrow */
+@media print {
+  .artwork,
+  .artwork > pre,
+  .sourcecode {
+    margin-bottom: 1em;
+  }
+}
+/* Avoid narrow tables forcing too narrow table captions, which may render badly */
+table {
+  min-width: 20em;
+}
+/* ol type a */
+ol.type-a { list-style-type: lower-alpha; }
+ol.type-A { list-style-type: upper-alpha; }
+ol.type-i { list-style-type: lower-roman; }
+ol.type-I { list-style-type: upper-roman; }
+/* Apply the print table and row borders in general, on request from the RPC,
+and increase the contrast between border and odd row background slightly */
+table {
+  border: 1px solid #ddd;
+}
+td {
+  border-top: 1px solid #ddd;
+}
+tr {
+  break-inside: avoid;
+}
+tr:nth-child(2n+1) > td {
+  background-color: #f8f8f8;
+}
+/* Use style rules to govern display of the TOC. */
+@media screen and (max-width: 1023px) {
+  #toc nav { display: none; }
+  #toc.active nav { display: block; }
+}
+/* Add support for keepWithNext */
+.keepWithNext {
+  break-after: avoid-page;
+  break-after: avoid-page;
+}
+/* Add support for keepWithPrevious */
+.keepWithPrevious {
+  break-before: avoid-page;
+}
+/* Change the approach to avoiding breaks inside artwork etc. */
+figure, pre, table, .artwork, .sourcecode  {
+  break-before: auto;
+  break-after: auto;
+}
+/* Avoid breaks between <dt> and <dd> */
+dl {
+  break-before: auto;
+  break-inside: auto;
+}
+dt {
+  break-before: auto;
+  break-after: avoid-page;
+}
+dd {
+  break-before: avoid-page;
+  break-after: auto;
+  orphans: 3;
+  widows: 3
+}
+span.break, dd.break {
+  margin-bottom: 0;
+  min-height: 0;
+  break-before: auto;
+  break-inside: auto;
+  break-after: auto;
+}
+/* Undo break-before ToC */
+@media print {
+  #toc {
+    break-before: auto;
+  }
+}
+/* Text in compact lists should not get extra bottom margin space,
+   since that would makes the list not compact */
+ul.compact p, .ulCompact p,
+ol.compact p, .olCompact p {
+ margin: 0;
+}
+/* But the list as a whole needs the extra space at the end */
+section ul.compact,
+section .ulCompact,
+section ol.compact,
+section .olCompact {
+  margin-bottom: 1em;                    /* same as p not within ul.compact etc. */
+}
+/* The tt and code background above interferes with for instance table cell
+   backgrounds.  Changed to something a bit more selective. */
+tt, code {
+  background-color: transparent;
+}
+p tt, p code, li tt, li code, dt tt, dt code {
+  background-color: #f8f8f8;
+}
+/* Tweak the pre margin -- 0px doesn't come out well */
+pre {
+   margin-top: 0.5px;
+}
+/* Tweak the compact list text */
+ul.compact, .ulCompact,
+ol.compact, .olCompact,
+dl.compact, .dlCompact {
+  line-height: normal;
+}
+/* Don't add top margin for nested lists */
+li > ul, li > ol, li > dl,
+dd > ul, dd > ol, dd > dl,
+dl > dd > dl {
+  margin-top: initial;
+}
+/* Elements that should not be rendered on the same line as a <dt> */
+/* This should match the element list in writer.text.TextWriter.render_dl() */
+dd > div.artwork:first-child,
+dd > aside:first-child,
+dd > blockquote:first-child,
+dd > figure:first-child,
+dd > ol:first-child,
+dd > div.sourcecode:first-child,
+dd > table:first-child,
+dd > ul:first-child {
+  clear: left;
+}
+/* fix for weird browser behaviour when <dd/> is empty */
+dt+dd:empty::before{
+  content: "\00a0";
+}
+/* Make paragraph spacing inside <li> smaller than in body text, to fit better within the list */
+li > p {
+  margin-bottom: 0.5em
+}
+/* Don't let p margin spill out from inside list items */
+li > p:last-of-type:only-child {
+  margin-bottom: 0;
+}
+</style>
+<link href="rfc-local.css" rel="stylesheet" type="text/css">
+<script type="application/javascript">async function addMetadata(){try{const e=document.styleSheets[0].cssRules;for(let t=0;t<e.length;t++)if(/#identifiers/.exec(e[t].selectorText)){const a=e[t].cssText.replace("#identifiers","#external-updates");document.styleSheets[0].insertRule(a,document.styleSheets[0].cssRules.length)}}catch(e){console.log(e)}const e=document.getElementById("external-metadata");if(e)try{var t,a="",o=function(e){const t=document.getElementsByTagName("meta");for(let a=0;a<t.length;a++)if(t[a].getAttribute("name")===e)return t[a].getAttribute("content");return""}("rfc.number");if(o){t="https://www.rfc-editor.org/rfc/rfc"+o+".json";try{const e=await fetch(t);a=await e.json()}catch(e){t=document.URL.indexOf("html")>=0?document.URL.replace(/html$/,"json"):document.URL+".json";const o=await fetch(t);a=await o.json()}}if(!a)return;e.style.display="block";const s="",d="https://datatracker.ietf.org/doc",n="https://datatracker.ietf.org/ipr/search",c="https://www.rfc-editor.org/info",l=a.doc_id.toLowerCase(),i=a.doc_id.slice(0,3).toLowerCase(),f=a.doc_id.slice(3).replace(/^0+/,""),u={status:"Status",obsoletes:"Obsoletes",obsoleted_by:"Obsoleted By",updates:"Updates",updated_by:"Updated By",see_also:"See Also",errata_url:"Errata"};let h="<dl style='overflow:hidden' id='external-updates'>";["status","obsoletes","obsoleted_by","updates","updated_by","see_also","errata_url"].forEach(e=>{if("status"==e){a[e]=a[e].toLowerCase();var t=a[e].split(" "),o=t.length,w="",p=1;for(let e=0;e<o;e++)p<o?w=w+r(t[e])+" ":w+=r(t[e]),p++;a[e]=w}else if("obsoletes"==e||"obsoleted_by"==e||"updates"==e||"updated_by"==e){var g,m="",b=1;g=a[e].length;for(let t=0;t<g;t++)a[e][t]&&(a[e][t]=String(a[e][t]).toLowerCase(),m=b<g?m+"<a href='"+s+"/rfc/".concat(a[e][t])+"'>"+a[e][t].slice(3)+"</a>, ":m+"<a href='"+s+"/rfc/".concat(a[e][t])+"'>"+a[e][t].slice(3)+"</a>",b++);a[e]=m}else if("see_also"==e){var y,L="",C=1;y=a[e].length;for(let t=0;t<y;t++)if(a[e][t]){a[e][t]=String(a[e][t]);var _=a[e][t].slice(0,3),v=a[e][t].slice(3).replace(/^0+/,"");L=C<y?"RFC"!=_?L+"<a href='"+s+"/info/"+_.toLowerCase().concat(v.toLowerCase())+"'>"+_+" "+v+"</a>, ":L+"<a href='"+s+"/info/"+_.toLowerCase().concat(v.toLowerCase())+"'>"+v+"</a>, ":"RFC"!=_?L+"<a href='"+s+"/info/"+_.toLowerCase().concat(v.toLowerCase())+"'>"+_+" "+v+"</a>":L+"<a href='"+s+"/info/"+_.toLowerCase().concat(v.toLowerCase())+"'>"+v+"</a>",C++}a[e]=L}else if("errata_url"==e){var R="";R=a[e]?R+"<a href='"+a[e]+"'>Errata exist</a> | <a href='"+d+"/"+l+"'>Datatracker</a>| <a href='"+n+"/?"+i+"="+f+"&submit="+i+"'>IPR</a> | <a href='"+c+"/"+l+"'>Info page</a>":"<a href='"+d+"/"+l+"'>Datatracker</a> | <a href='"+n+"/?"+i+"="+f+"&submit="+i+"'>IPR</a> | <a href='"+c+"/"+l+"'>Info page</a>",a[e]=R}""!=a[e]?"Errata"==u[e]?h+=`<dt>More info:</dt><dd>${a[e]}</dd>`:h+=`<dt>${u[e]}:</dt><dd>${a[e]}</dd>`:"Errata"==u[e]&&(h+=`<dt>More info:</dt><dd>${a[e]}</dd>`)}),h+="</dl>",e.innerHTML=h}catch(e){console.log(e)}else console.log("Could not locate metadata <div> element");function r(e){return e.charAt(0).toUpperCase()+e.slice(1)}}window.removeEventListener("load",addMetadata),window.addEventListener("load",addMetadata);</script>
+</head>
+<body class="xml2rfc">
+<table class="ears">
+<thead><tr>
+<td class="left"></td>
+<td class="center">openid-connect-enterprise-extensions</td>
+<td class="right">February 2026</td>
+</tr></thead>
+<tfoot><tr>
+<td class="left">Hardt &amp; McGuinness</td>
+<td class="center">Standards Track</td>
+<td class="right">[Page]</td>
+</tr></tfoot>
+</table>
+<div id="external-metadata" class="document-information"></div>
+<div id="internal-metadata" class="document-information">
+<dl id="identifiers">
+<dt class="label-workgroup">Workgroup:</dt>
+<dd class="workgroup">OpenID Connect</dd>
+<dt class="label-published">Published:</dt>
+<dd class="published">
+<time datetime="2026-02-26" class="published">26 February 2026</time>
+    </dd>
+<dt class="label-authors">Authors:</dt>
+<dd class="authors">
+<div class="author">
+      <div class="author-name">D. Hardt</div>
+<div class="org">Hellō</div>
+</div>
+<div class="author">
+      <div class="author-name">K. McGuinness</div>
+<div class="org">Independent</div>
+</div>
+</dd>
+</dl>
+</div>
+<h1 id="title">OpenID Connect Enterprise Extensions 1.0 - draft 02</h1>
+<section id="section-abstract">
+      <h2 id="abstract"><a href="#abstract" class="selfRef">Abstract</a></h2>
+<p id="section-abstract-1">OpenID Connect 1.0 has become a popular choice for single sign-on in enterprise use cases. To improve interoperability, OpenID Connect Enterprise Extensions specifies a number of common or desirable extensions to OpenID Connect.<a href="#section-abstract-1" class="pilcrow">¶</a></p>
+</section>
+<div id="toc">
+<section id="section-toc.1">
+        <a href="#" onclick="scroll(0,0)" class="toplink">▲</a><h2 id="name-table-of-contents">
+<a href="#name-table-of-contents" class="section-name selfRef">Table of Contents</a>
+        </h2>
+<nav class="toc"><ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.1">
+            <p id="section-toc.1-1.1.1" class="keepWithNext"><a href="#section-1" class="auto internal xref">1</a>.  <a href="#name-introduction" class="internal xref">Introduction</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.1.2.1">
+                <p id="section-toc.1-1.1.2.1.1" class="keepWithNext"><a href="#section-1.1" class="auto internal xref">1.1</a>.  <a href="#name-requirements-notation-and-c" class="internal xref">Requirements Notation and Conventions</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.1.2.2">
+                <p id="section-toc.1-1.1.2.2.1" class="keepWithNext"><a href="#section-1.2" class="auto internal xref">1.2</a>.  <a href="#name-terminology" class="internal xref">Terminology</a></p>
+</li>
+            </ul>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.2">
+            <p id="section-toc.1-1.2.1"><a href="#section-2" class="auto internal xref">2</a>.  <a href="#name-id-token-claims" class="internal xref">ID Token Claims</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.2.2.1">
+                <p id="section-toc.1-1.2.2.1.1"><a href="#section-2.1" class="auto internal xref">2.1</a>.  <a href="#name-session_expiry" class="internal xref">session_expiry</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.2.2.2">
+                <p id="section-toc.1-1.2.2.2.1"><a href="#section-2.2" class="auto internal xref">2.2</a>.  <a href="#name-tenant" class="internal xref">tenant</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.2.2.3">
+                <p id="section-toc.1-1.2.2.3.1"><a href="#section-2.3" class="auto internal xref">2.3</a>.  <a href="#name-aud_sub" class="internal xref">aud_sub</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.2.2.4">
+                <p id="section-toc.1-1.2.2.4.1"><a href="#section-2.4" class="auto internal xref">2.4</a>.  <a href="#name-aud_tenant" class="internal xref">aud_tenant</a></p>
+</li>
+            </ul>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.3">
+            <p id="section-toc.1-1.3.1"><a href="#section-3" class="auto internal xref">3</a>.  <a href="#name-authentication-request-para" class="internal xref">Authentication Request Parameters</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.3.2.1">
+                <p id="section-toc.1-1.3.2.1.1"><a href="#section-3.1" class="auto internal xref">3.1</a>.  <a href="#name-domain_hint" class="internal xref">domain_hint</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.3.2.2">
+                <p id="section-toc.1-1.3.2.2.1"><a href="#section-3.2" class="auto internal xref">3.2</a>.  <a href="#name-tenant-2" class="internal xref">tenant</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.3.2.3">
+                <p id="section-toc.1-1.3.2.3.1"><a href="#section-3.3" class="auto internal xref">3.3</a>.  <a href="#name-client_tenant" class="internal xref">client_tenant</a></p>
+</li>
+            </ul>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4">
+            <p id="section-toc.1-1.4.1"><a href="#section-4" class="auto internal xref">4</a>.  <a href="#name-client-registration-paramet" class="internal xref">Client Registration Parameters</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4.2.1">
+                <p id="section-toc.1-1.4.2.1.1"><a href="#section-4.1" class="auto internal xref">4.1</a>.  <a href="#name-tenants" class="internal xref">tenants</a></p>
+</li>
+            </ul>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5">
+            <p id="section-toc.1-1.5.1"><a href="#section-5" class="auto internal xref">5</a>.  <a href="#name-login-from-a-third-party-pa" class="internal xref">Login from a Third Party Parameters</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.1">
+                <p id="section-toc.1-1.5.2.1.1"><a href="#section-5.1" class="auto internal xref">5.1</a>.  <a href="#name-client_id" class="internal xref">client_id</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.2">
+                <p id="section-toc.1-1.5.2.2.1"><a href="#section-5.2" class="auto internal xref">5.2</a>.  <a href="#name-domain_hint-2" class="internal xref">domain_hint</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.3">
+                <p id="section-toc.1-1.5.2.3.1"><a href="#section-5.3" class="auto internal xref">5.3</a>.  <a href="#name-tenant-3" class="internal xref">tenant</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.4">
+                <p id="section-toc.1-1.5.2.4.1"><a href="#section-5.4" class="auto internal xref">5.4</a>.  <a href="#name-client_tenant-2" class="internal xref">client_tenant</a></p>
+</li>
+            </ul>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6">
+            <p id="section-toc.1-1.6.1"><a href="#section-6" class="auto internal xref">6</a>.  <a href="#name-security-considerations" class="internal xref">Security Considerations</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.1">
+                <p id="section-toc.1-1.6.2.1.1"><a href="#section-6.1" class="auto internal xref">6.1</a>.  <a href="#name-op-security-considerations" class="internal xref">OP Security Considerations</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.1.2.1">
+                    <p id="section-toc.1-1.6.2.1.2.1.1"><a href="#section-6.1.1" class="auto internal xref">6.1.1</a>.  <a href="#name-tenant-isolation" class="internal xref">Tenant Isolation</a></p>
+</li>
+                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.1.2.2">
+                    <p id="section-toc.1-1.6.2.1.2.2.1"><a href="#section-6.1.2" class="auto internal xref">6.1.2</a>.  <a href="#name-client-tenant-validation" class="internal xref">Client Tenant Validation</a></p>
+</li>
+                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.1.2.3">
+                    <p id="section-toc.1-1.6.2.1.2.3.1"><a href="#section-6.1.3" class="auto internal xref">6.1.3</a>.  <a href="#name-subject-identifier-collisio" class="internal xref">Subject Identifier Collision</a></p>
+</li>
+                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.1.2.4">
+                    <p id="section-toc.1-1.6.2.1.2.4.1"><a href="#section-6.1.4" class="auto internal xref">6.1.4</a>.  <a href="#name-token-injection-prevention" class="internal xref">Token Injection Prevention</a></p>
+</li>
+                </ul>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.2">
+                <p id="section-toc.1-1.6.2.2.1"><a href="#section-6.2" class="auto internal xref">6.2</a>.  <a href="#name-rp-security-considerations" class="internal xref">RP Security Considerations</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.2.2.1">
+                    <p id="section-toc.1-1.6.2.2.2.1.1"><a href="#section-6.2.1" class="auto internal xref">6.2.1</a>.  <a href="#name-tenant-claim-validation" class="internal xref">Tenant Claim Validation</a></p>
+</li>
+                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.2.2.2">
+                    <p id="section-toc.1-1.6.2.2.2.2.1"><a href="#section-6.2.2" class="auto internal xref">6.2.2</a>.  <a href="#name-aud_tenant-claim-validation" class="internal xref">aud_tenant Claim Validation</a></p>
+</li>
+                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.2.2.3">
+                    <p id="section-toc.1-1.6.2.2.2.3.1"><a href="#section-6.2.3" class="auto internal xref">6.2.3</a>.  <a href="#name-account-identifier-uniquene" class="internal xref">Account Identifier Uniqueness</a></p>
+</li>
+                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.2.2.4">
+                    <p id="section-toc.1-1.6.2.2.2.4.1"><a href="#section-6.2.4" class="auto internal xref">6.2.4</a>.  <a href="#name-cross-tenant-request-forger" class="internal xref">Cross-Tenant Request Forgery</a></p>
+</li>
+                </ul>
+</li>
+            </ul>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7">
+            <p id="section-toc.1-1.7.1"><a href="#section-7" class="auto internal xref">7</a>.  <a href="#name-privacy-considerations" class="internal xref">Privacy Considerations</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8">
+            <p id="section-toc.1-1.8.1"><a href="#section-8" class="auto internal xref">8</a>.  <a href="#name-iana-considerations" class="internal xref">IANA Considerations</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.9">
+            <p id="section-toc.1-1.9.1"><a href="#section-9" class="auto internal xref">9</a>.  <a href="#name-references" class="internal xref">References</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.9.2.1">
+                <p id="section-toc.1-1.9.2.1.1"><a href="#section-9.1" class="auto internal xref">9.1</a>.  <a href="#name-normative-references" class="internal xref">Normative References</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.9.2.2">
+                <p id="section-toc.1-1.9.2.2.1"><a href="#section-9.2" class="auto internal xref">9.2</a>.  <a href="#name-informative-references" class="internal xref">Informative References</a></p>
+</li>
+            </ul>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.10">
+            <p id="section-toc.1-1.10.1"><a href="#appendix-A" class="auto internal xref">Appendix A</a>.  <a href="#name-enterprise-tenancy-models" class="internal xref">Enterprise Tenancy Models</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.10.2.1">
+                <p id="section-toc.1-1.10.2.1.1"><a href="#appendix-A.1" class="auto internal xref">A.1</a>.  <a href="#name-op-tenancy" class="internal xref">OP Tenancy</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.10.2.2">
+                <p id="section-toc.1-1.10.2.2.1"><a href="#appendix-A.2" class="auto internal xref">A.2</a>.  <a href="#name-op-tenant-communication" class="internal xref">OP Tenant Communication</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.10.2.3">
+                <p id="section-toc.1-1.10.2.3.1"><a href="#appendix-A.3" class="auto internal xref">A.3</a>.  <a href="#name-rp-tenancy" class="internal xref">RP Tenancy</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.10.2.4">
+                <p id="section-toc.1-1.10.2.4.1"><a href="#appendix-A.4" class="auto internal xref">A.4</a>.  <a href="#name-rp-tenant-communication" class="internal xref">RP Tenant Communication</a></p>
+</li>
+            </ul>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11">
+            <p id="section-toc.1-1.11.1"><a href="#appendix-B" class="auto internal xref">Appendix B</a>.  <a href="#name-acknowledgements" class="internal xref">Acknowledgements</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12">
+            <p id="section-toc.1-1.12.1"><a href="#appendix-C" class="auto internal xref">Appendix C</a>.  <a href="#name-notices" class="internal xref">Notices</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.13">
+            <p id="section-toc.1-1.13.1"><a href="#appendix-D" class="auto internal xref">Appendix D</a>.  <a href="#name-document-history" class="internal xref">Document History</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.14">
+            <p id="section-toc.1-1.14.1"><a href="#appendix-E" class="auto internal xref"></a><a href="#name-authors-addresses" class="internal xref">Authors' Addresses</a></p>
+</li>
+        </ul>
+</nav>
+</section>
+</div>
+<div id="introduction">
+<section id="section-1">
+      <h2 id="name-introduction">
+<a href="#section-1" class="section-number selfRef">1. </a><a href="#name-introduction" class="section-name selfRef">Introduction</a>
+      </h2>
+<p id="section-1-1">OpenID Connect 1.0 is a widely adopted identity protocol that enables client applications, known as relying parties (RPs), to verify the identity of end-users based on authentication performed by a trusted service, the OpenID Provider (OP).<a href="#section-1-1" class="pilcrow">¶</a></p>
+<p id="section-1-2">Initial adoption of OpenID Connect was by sites providing personal identity to applications. OpenID Connect has become a popular choice in enterprise use cases, and implementors have defined their own extensions for use cases that were not addressed in the original specification.<a href="#section-1-2" class="pilcrow">¶</a></p>
+<p id="section-1-3">To improve interoperability between systems, OpenID Connect Enterprise Extensions specifies optional claims that may be included in an ID Token, optional parameters that may be included in an authentication request, optional client registration parameters, and optional parameters that may be included when initiating login from a third party.<a href="#section-1-3" class="pilcrow">¶</a></p>
+<p id="section-1-4">Enterprise deployments of OpenID Connect often involve multi-tenancy on both sides of the protocol. An OpenID Provider (OP) may serve multiple organizations, each with their own users and policies. Similarly, a Relying Party (RP) may be a SaaS application serving multiple customer organizations, each requiring isolation of their users and data.<a href="#section-1-4" class="pilcrow">¶</a></p>
+<p id="section-1-5">This specification addresses three key challenges in multi-tenant deployments:<a href="#section-1-5" class="pilcrow">¶</a></p>
+<p id="section-1-6"><strong>OP Tenant Identification</strong>: When an OP serves multiple tenants using a single issuer identifier, the standard <code>iss</code> and <code>sub</code> claims are insufficient to uniquely identify a user across tenants. This specification defines the <code>tenant</code> claim to disambiguate users and the <code>tenant</code> and <code>domain_hint</code> authentication request parameters to allow RPs to specify which OP tenant to authenticate against.<a href="#section-1-6" class="pilcrow">¶</a></p>
+<p id="section-1-7"><strong>RP Tenant Identification</strong>: When an RP serves multiple tenants using a shared client registration, the OP has no standard way to know which RP tenant initiated the authentication request. This specification defines the <code>client_tenant</code> authentication request parameter and the <code>aud_tenant</code> ID Token claim to enable RPs to communicate their tenant context to the OP, allowing the OP to apply tenant-specific policies and echo the tenant identifier back in the token.<a href="#section-1-7" class="pilcrow">¶</a></p>
+<p id="section-1-8"><strong>Account Linking</strong>: When an OP maintains account linkages to RP accounts, the standard claims do not provide a mechanism to communicate the RP's account identifier. This specification defines the <code>aud_sub</code> claim to allow the OP to include the RP's account identifier in the ID Token, and the <code>aud_tenant</code> claim to scope that identifier to a specific RP tenant when applicable.<a href="#section-1-8" class="pilcrow">¶</a></p>
+<div id="requirements-notation-and-conventions">
+<section id="section-1.1">
+        <h3 id="name-requirements-notation-and-c">
+<a href="#section-1.1" class="section-number selfRef">1.1. </a><a href="#name-requirements-notation-and-c" class="section-name selfRef">Requirements Notation and Conventions</a>
+        </h3>
+<p id="section-1.1-1">The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+"SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
+document are to be interpreted as described in <a href="#RFC2119">RFC2119</a>.<a href="#section-1.1-1" class="pilcrow">¶</a></p>
+<p id="section-1.1-2">In the .txt version of this specification,
+values are quoted to indicate that they are to be taken literally.
+When using these values in protocol messages,
+the quotes MUST NOT be used as part of the value.
+In the HTML version of this specification,
+values to be taken literally are indicated by
+the use of <em>this fixed-width font</em>.<a href="#section-1.1-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="terminology">
+<section id="section-1.2">
+        <h3 id="name-terminology">
+<a href="#section-1.2" class="section-number selfRef">1.2. </a><a href="#name-terminology" class="section-name selfRef">Terminology</a>
+        </h3>
+<p id="section-1.2-1">This specification defines the following terms:<a href="#section-1.2-1" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="section-1.2-2.1">
+            <p id="section-1.2-2.1.1"><strong>Account</strong>: A set of claims about a user.<a href="#section-1.2-2.1.1" class="pilcrow">¶</a></p>
+</li>
+          <li class="normal" id="section-1.2-2.2">
+            <p id="section-1.2-2.2.1"><strong>Tenant</strong>: A logically isolated entity that represents a distinct organizational or administrative boundary. A tenant may contain accounts managed by individuals or by an organization. Both an OpenID Provider (OP) and a Relying Party (RP) may have a single tenant or multiple tenants. When referring to a tenant within an OP, it is called an "OP tenant". When referring to a tenant within an RP, it is called an "RP tenant".<a href="#section-1.2-2.2.1" class="pilcrow">¶</a></p>
+</li>
+        </ul>
+</section>
+</div>
+</section>
+</div>
+<div id="id-token-claims">
+<section id="section-2">
+      <h2 id="name-id-token-claims">
+<a href="#section-2" class="section-number selfRef">2. </a><a href="#name-id-token-claims" class="section-name selfRef">ID Token Claims</a>
+      </h2>
+<p id="section-2-1">An ID Token is defined in Section 2 of <a href="#OpenID%20Connect%20Core%201.0">OpenID Connect Core 1.0</a>.<a href="#section-2-1" class="pilcrow">¶</a></p>
+<p id="section-2-2">Following are OPTIONAL claims that may be included in an ID Token:<a href="#section-2-2" class="pilcrow">¶</a></p>
+<div id="session-expiry">
+<section id="section-2.1">
+        <h3 id="name-session_expiry">
+<a href="#section-2.1" class="section-number selfRef">2.1. </a><a href="#name-session_expiry" class="section-name selfRef">session_expiry</a>
+        </h3>
+<p id="section-2.1-1">The <code>session_expiry</code> claim is a JSON integer that represents the Unix timestamp (seconds since epoch) indicating when a session created from the ID Token MUST expire.<a href="#section-2.1-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="tenant">
+<section id="section-2.2">
+        <h3 id="name-tenant">
+<a href="#section-2.2" class="section-number selfRef">2.2. </a><a href="#name-tenant" class="section-name selfRef">tenant</a>
+        </h3>
+<p id="section-2.2-1">The <code>tenant</code> claim is a JSON string that represents an OP tenant identifier. This claim is OPTIONAL and MAY be included in ID Tokens.<a href="#section-2.2-1" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="section-2.2-2.1">
+            <p id="section-2.2-2.1.1"><strong>Single-tenant OPs</strong>: Single-tenant OPs SHOULD omit the <code>tenant</code> claim.<a href="#section-2.2-2.1.1" class="pilcrow">¶</a></p>
+</li>
+          <li class="normal" id="section-2.2-2.2">
+            <p id="section-2.2-2.2.1"><strong>Multi-tenant OPs using a single issuer</strong>: Multi-tenant OPs using a single issuer identifier SHOULD include the <code>tenant</code> claim to identify the OP tenant. The value MUST be a stable, opaque to the RP, OP unique identifier or a well known special value described below.<a href="#section-2.2-2.2.1" class="pilcrow">¶</a></p>
+<ul class="compact normal">
+<li class="compact normal" id="section-2.2-2.2.2.1">The combination of <code>iss</code>, <code>tenant</code>, and <code>sub</code> MUST be unique across all OP tenants.<a href="#section-2.2-2.2.2.1" class="pilcrow">¶</a>
+</li>
+              <li class="compact normal" id="section-2.2-2.2.2.2">If the OP uses <code>pairwise</code> subject identifiers, the same user MAY have the same <code>sub</code> for the same <code>client_id</code> regardless of OP tenant. The <code>tenant</code> claim SHOULD be included in the uniqueness requirement (<code>iss</code> + <code>tenant</code> + <code>sub</code>) to disambiguate subjects across tenants.<a href="#section-2.2-2.2.2.2" class="pilcrow">¶</a>
+</li>
+              <li class="compact normal" id="section-2.2-2.2.2.3">If the OP uses <code>public</code> subject identifiers, the <code>sub</code> value MUST be the same across all RPs/clients and all OP tenants. The <code>tenant</code> claim MUST be included in the uniqueness requirement (<code>iss</code> + <code>tenant</code> + <code>sub</code>) to disambiguate subjects across tenants.<a href="#section-2.2-2.2.2.3" class="pilcrow">¶</a>
+</li>
+            </ul>
+</li>
+          <li class="normal" id="section-2.2-2.3">
+            <p id="section-2.2-2.3.1"><strong>Multi-tenant OPs using tenant-specific issuer identifiers</strong>: Multi-tenant OPs using tenant-specific issuer identifiers SHOULD omit the <code>tenant</code> claim since the issuer identifier itself identifies the tenant.<a href="#section-2.2-2.3.1" class="pilcrow">¶</a></p>
+<ul class="compact normal">
+<li class="compact normal" id="section-2.2-2.3.2.1">Each tenant issuer identifier MUST be a valid URL per [OpenID Connect Core 1.0] Section 2.<a href="#section-2.2-2.3.2.1" class="pilcrow">¶</a>
+</li>
+              <li class="compact normal" id="section-2.2-2.3.2.2">The combination of <code>iss</code> and <code>sub</code> MUST be unique per tenant.<a href="#section-2.2-2.3.2.2" class="pilcrow">¶</a>
+</li>
+              <li class="compact normal" id="section-2.2-2.3.2.3">If the OP uses <code>pairwise</code> subject identifiers, the <code>sub</code> value MUST differ across <code>client_id</code> values within each tenant. The combination of <code>iss</code> + <code>client_id</code> + <code>sub</code> MUST be unique across all tenants.<a href="#section-2.2-2.3.2.3" class="pilcrow">¶</a>
+</li>
+              <li class="compact normal" id="section-2.2-2.3.2.4">If the OP uses <code>public</code> subject identifiers, the <code>sub</code> value MUST be the same across all RPs/clients within each tenant. The <code>sub</code> value MAY be the same across tenants, but the combination of <code>iss</code> + <code>sub</code> MUST be unique across all tenants.<a href="#section-2.2-2.3.2.4" class="pilcrow">¶</a>
+</li>
+            </ul>
+</li>
+          <li class="normal" id="section-2.2-2.4">
+            <p id="section-2.2-2.4.1"><strong>Special values</strong>: The <code>tenant</code> claim MAY have the well-known value <code>personal</code> or <code>organization</code> instead of a unique identifier.<a href="#section-2.2-2.4.1" class="pilcrow">¶</a></p>
+<ul class="compact normal">
+<li class="compact normal" id="section-2.2-2.4.2.1">
+                <code>personal</code>: Indicates that accounts are managed by individuals rather than by a specific organizational tenant.<a href="#section-2.2-2.4.2.1" class="pilcrow">¶</a>
+</li>
+              <li class="compact normal" id="section-2.2-2.4.2.2">
+                <code>organization</code>: Indicates that accounts are managed by an organization.<a href="#section-2.2-2.4.2.2" class="pilcrow">¶</a>
+</li>
+            </ul>
+</li>
+        </ul>
+<p id="section-2.2-3">For multi-tenant OPs using tenant-specific issuer identifiers, if the <code>tenant</code> claim is present and does not match the tenant identified by the <code>iss</code> value, the RP SHOULD treat this as an error condition.<a href="#section-2.2-3" class="pilcrow">¶</a></p>
+<ul class="compact">
+<li class="compact" id="section-2.2-4.1">
+            <strong>Discovery</strong>: If an OP publishes support for the <code>tenant</code> claim in the <code>claims_supported</code> metadata parameter (see [OpenID Connect Discovery 1.0]), then RPs SHOULD assume that the issuer supports multiple tenants and SHOULD expect the <code>tenant</code> claim to be present in ID Tokens.<a href="#section-2.2-4.1" class="pilcrow">¶</a>
+</li>
+        </ul>
+</section>
+</div>
+<div id="aud-sub">
+<section id="section-2.3">
+        <h3 id="name-aud_sub">
+<a href="#section-2.3" class="section-number selfRef">2.3. </a><a href="#name-aud_sub" class="section-name selfRef">aud_sub</a>
+        </h3>
+<p id="section-2.3-1">The <code>aud_sub</code> claim is an opaque JSON string that represents the identifier the RP has for the account. This claim is OPTIONAL. How the OP acquires the <code>aud_sub</code> and how the OP account and RP account linking is established is out of scope of this specification.<a href="#section-2.3-1" class="pilcrow">¶</a></p>
+<p id="section-2.3-2">The <code>aud_sub</code> value MUST be unique within the context of the <code>client_id</code>.<a href="#section-2.3-2" class="pilcrow">¶</a></p>
+<p id="section-2.3-3">When the <code>aud_tenant</code> claim is present, the <code>aud_sub</code> claim represents the account identifier within the context of that specific RP tenant. See Section "aud_tenant" for uniqueness requirements.<a href="#section-2.3-3" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="aud-tenant">
+<section id="section-2.4">
+        <h3 id="name-aud_tenant">
+<a href="#section-2.4" class="section-number selfRef">2.4. </a><a href="#name-aud_tenant" class="section-name selfRef">aud_tenant</a>
+        </h3>
+<p id="section-2.4-1">The <code>aud_tenant</code> claim is a JSON string that represents an RP tenant identifier. This claim is OPTIONAL and is only included when the RP is multi-tenant and the OP knows the RP tenant identifier (see Appendix A for how the RP communicates its tenant identifier to the OP).<a href="#section-2.4-1" class="pilcrow">¶</a></p>
+<p id="section-2.4-2">When the RP provides the <code>client_tenant</code> authentication request parameter, the <code>aud_tenant</code> claim value MUST be the same value that the RP provided in that parameter. When the OP determines the RP tenant identifier through other means (e.g., <code>domain_hint</code>, <code>login_hint</code>, default tenant selection, or end-user selection), the <code>aud_tenant</code> claim value MUST be a valid RP tenant identifier for the client. The value is opaque to the OP (the OP does not need to understand its semantic meaning). The value MUST be a stable identifier that is unique within the context of the <code>client_id</code> used in the authentication request, ensuring that when multiple RP tenants share the same <code>client_id</code>, each tenant can be uniquely identified.<a href="#section-2.4-2" class="pilcrow">¶</a></p>
+<p id="section-2.4-3">When <code>aud_tenant</code> is present, the <code>aud_sub</code> claim represents the identifier the RP has for the account within the context of that specific RP tenant. The combination of <code>aud</code> + <code>aud_tenant</code> and <code>aud_sub</code> MUST be unique within the RP.<a href="#section-2.4-3" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+</div>
+<div id="authentication-request-parameters">
+<section id="section-3">
+      <h2 id="name-authentication-request-para">
+<a href="#section-3" class="section-number selfRef">3. </a><a href="#name-authentication-request-para" class="section-name selfRef">Authentication Request Parameters</a>
+      </h2>
+<p id="section-3-1">An Authentication request is defined in Section 3.1.2.1 of [OpenID Connect Core 1.0].<a href="#section-3-1" class="pilcrow">¶</a></p>
+<p id="section-3-2">Following are OPTIONAL parameters that may be included in an Authentication Request:<a href="#section-3-2" class="pilcrow">¶</a></p>
+<div id="domain-hint">
+<section id="section-3.1">
+        <h3 id="name-domain_hint">
+<a href="#section-3.1" class="section-number selfRef">3.1. </a><a href="#name-domain_hint" class="section-name selfRef">domain_hint</a>
+        </h3>
+<p id="section-3.1-1">The <code>domain_hint</code> parameter provides a hint for the OP to determine which OP tenant to present to the user to authenticate to. This parameter is typically a domain name or email domain (e.g., <code>example.com</code>) that helps the OP identify the appropriate tenant. The <code>domain_hint</code> parameter is a user experience hint and is not guaranteed to uniquely identify a tenant.<a href="#section-3.1-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="tenant-1">
+<section id="section-3.2">
+        <h3 id="name-tenant-2">
+<a href="#section-3.2" class="section-number selfRef">3.2. </a><a href="#name-tenant-2" class="section-name selfRef">tenant</a>
+        </h3>
+<p id="section-3.2-1">The <code>tenant</code> parameter is the explicit OP tenant identifier value that corresponds to the <code>tenant</code> claim the RP would like included in the ID Token. This parameter takes precedence over <code>domain_hint</code> when both are present.<a href="#section-3.2-1" class="pilcrow">¶</a></p>
+<p id="section-3.2-2">The <code>tenant</code> parameter value MUST match one of the following:
+- The value <code>personal</code> to indicate the RP would like the user to use an account managed by the user (personal account)
+- The value <code>organization</code> to indicate the RP would like the user to use an account managed by an organization (organizational account)
+- A stable, opaque OP tenant identifier value for multi-tenant OPs<a href="#section-3.2-2" class="pilcrow">¶</a></p>
+<p id="section-3.2-3">If the <code>tenant</code> parameter value does not match any OP tenant, the OP SHOULD return an <code>invalid_request</code> error or proceed with the authentication using the OP's default tenant selection logic. The specific behavior is implementation-dependent.<a href="#section-3.2-3" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="client-tenant">
+<section id="section-3.3">
+        <h3 id="name-client_tenant">
+<a href="#section-3.3" class="section-number selfRef">3.3. </a><a href="#name-client_tenant" class="section-name selfRef">client_tenant</a>
+        </h3>
+<p id="section-3.3-1">The <code>client_tenant</code> parameter is an OPTIONAL parameter that the RP includes to communicate its RP tenant identifier to the OP. This parameter is used when the RP is multi-tenant and uses a shared <code>client_id</code> across multiple RP tenants (see Appendix A for details on multi-tenant RP models).<a href="#section-3.3-1" class="pilcrow">¶</a></p>
+<p id="section-3.3-2">The client MAY register allowed tenants using the <code>tenants</code> client registration parameter. When the <code>client_tenant</code> authentication request parameter is provided, the OP SHOULD validate that the <code>client_tenant</code> value corresponds to a valid RP tenant identifier that was registered for this client.<a href="#section-3.3-2" class="pilcrow">¶</a></p>
+<p id="section-3.3-3">The <code>client_tenant</code> parameter value MUST be a stable identifier that is unique within the context of the <code>client_id</code> used in the authentication request, ensuring that when multiple RP tenants share the same <code>client_id</code>, each tenant can be uniquely identified. The value is opaque to the OP (the OP does not need to understand its semantic meaning) and MUST be echoed back in the <code>aud_tenant</code> claim.<a href="#section-3.3-3" class="pilcrow">¶</a></p>
+<p id="section-3.3-4">The OP MUST treat the <code>redirect_uri</code> as opaque and MUST NOT attempt to identify an RP tenant from a specific URL endpoint or pattern.<a href="#section-3.3-4" class="pilcrow">¶</a></p>
+<p id="section-3.3-5">When the RP uses only the <code>state</code> parameter or session context for tenant routing and does not provide a <code>client_tenant</code> parameter, the OP MUST omit the <code>aud_tenant</code> claim from the ID Token.<a href="#section-3.3-5" class="pilcrow">¶</a></p>
+<p id="section-3.3-6">If the <code>client_tenant</code> parameter is provided but the OP cannot determine the corresponding RP tenant (e.g., the value doesn't match any registered tenant identifier for the <code>client_id</code>), the OP SHOULD return an <code>invalid_request</code> error with an appropriate error description.<a href="#section-3.3-6" class="pilcrow">¶</a></p>
+<p id="section-3.3-7">If an RP is multi-tenant and uses a shared <code>client_id</code> but does not provide a <code>client_tenant</code> parameter, the OP MAY:
+- Attempt to resolve the RP tenant identifier using other available information (e.g., <code>domain_hint</code>, <code>login_hint</code>)
+- Select a default tenant for the client or fallback behavior (implementation-dependent)
+- Prompt the end-user to select a valid tenant for the client
+- Return an <code>invalid_request</code> error indicating that tenant identification is required<a href="#section-3.3-7" class="pilcrow">¶</a></p>
+<p id="section-3.3-8">If the OP successfully determines the RP tenant identifier through any of these means, it SHOULD include it in the <code>aud_tenant</code> claim of the ID Token.<a href="#section-3.3-8" class="pilcrow">¶</a></p>
+<p id="section-3.3-9">If the OP does not support RP tenant identification and receives a <code>client_tenant</code> parameter, the OP SHOULD ignore the parameter and MUST omit the <code>aud_tenant</code> claim from the ID Token.<a href="#section-3.3-9" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+</div>
+<div id="client-registration-parameters">
+<section id="section-4">
+      <h2 id="name-client-registration-paramet">
+<a href="#section-4" class="section-number selfRef">4. </a><a href="#name-client-registration-paramet" class="section-name selfRef">Client Registration Parameters</a>
+      </h2>
+<p id="section-4-1">Client registration is defined in [OpenID Connect Dynamic Client Registration 1.0].<a href="#section-4-1" class="pilcrow">¶</a></p>
+<p id="section-4-2">Following are OPTIONAL client registration parameters that may be included during client registration:<a href="#section-4-2" class="pilcrow">¶</a></p>
+<div id="tenants">
+<section id="section-4.1">
+        <h3 id="name-tenants">
+<a href="#section-4.1" class="section-number selfRef">4.1. </a><a href="#name-tenants" class="section-name selfRef">tenants</a>
+        </h3>
+<p id="section-4.1-1">The <code>tenants</code> parameter is a JSON array of strings that represents RP tenant identifiers. This parameter is OPTIONAL and MAY be included during client registration.<a href="#section-4.1-1" class="pilcrow">¶</a></p>
+<p id="section-4.1-2">When the <code>client_tenant</code> authentication request parameter is provided, the OP MAY use the <code>tenants</code> client registration parameter to validate that the <code>client_tenant</code> value corresponds to a valid RP tenant identifier that was registered for this client. The OP can use this information to apply RP tenant-specific policies or to validate the authentication request.<a href="#section-4.1-2" class="pilcrow">¶</a></p>
+<p id="section-4.1-3">If an RP registers the <code>tenants</code> client registration parameter, OPs SHOULD assume the RP is multi-tenant.<a href="#section-4.1-3" class="pilcrow">¶</a></p>
+<p id="section-4.1-4">For example:<a href="#section-4.1-4" class="pilcrow">¶</a></p>
+<div class="lang-json sourcecode" id="section-4.1-5">
+<pre>{
+  "client_id": "rp-shared-abcde",
+  "redirect_uris": ["https://app.example.com/callback"],
+  "tenants": ["acme-corp-tenant-id", "widgets-inc-tenant-id"]
+}
+</pre><a href="#section-4.1-5" class="pilcrow">¶</a>
+</div>
+</section>
+</div>
+</section>
+</div>
+<div id="login-from-a-third-party-parameters">
+<section id="section-5">
+      <h2 id="name-login-from-a-third-party-pa">
+<a href="#section-5" class="section-number selfRef">5. </a><a href="#name-login-from-a-third-party-pa" class="section-name selfRef">Login from a Third Party Parameters</a>
+      </h2>
+<p id="section-5-1">Initiating a login from a third party and a login initiation endpoint are defined in Section 4 of [OpenID Connect Core 1.0].<a href="#section-5-1" class="pilcrow">¶</a></p>
+<p id="section-5-2">Following are OPTIONAL parameters that may be included in request to the login initiation endpoint:<a href="#section-5-2" class="pilcrow">¶</a></p>
+<div id="client-id">
+<section id="section-5.1">
+        <h3 id="name-client_id">
+<a href="#section-5.1" class="section-number selfRef">5.1. </a><a href="#name-client_id" class="section-name selfRef">client_id</a>
+        </h3>
+<p id="section-5.1-1">The <code>client_id</code> value the RP should use when making the Authentication Request. This allows a multi-tenant application that hosts multiple tenants, each represented by a different <code>client_id</code>, to know which <code>client_id</code> to use.<a href="#section-5.1-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="domain-hint-1">
+<section id="section-5.2">
+        <h3 id="name-domain_hint-2">
+<a href="#section-5.2" class="section-number selfRef">5.2. </a><a href="#name-domain_hint-2" class="section-name selfRef">domain_hint</a>
+        </h3>
+<p id="section-5.2-1">The <code>domain_hint</code> value to be included in the Authentication Request.<a href="#section-5.2-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="tenant-2">
+<section id="section-5.3">
+        <h3 id="name-tenant-3">
+<a href="#section-5.3" class="section-number selfRef">5.3. </a><a href="#name-tenant-3" class="section-name selfRef">tenant</a>
+        </h3>
+<p id="section-5.3-1">The <code>tenant</code> value to be included in the Authentication Request.<a href="#section-5.3-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="client-tenant-1">
+<section id="section-5.4">
+        <h3 id="name-client_tenant-2">
+<a href="#section-5.4" class="section-number selfRef">5.4. </a><a href="#name-client_tenant-2" class="section-name selfRef">client_tenant</a>
+        </h3>
+<p id="section-5.4-1">The <code>client_tenant</code> value to be included in the Authentication Request.<a href="#section-5.4-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+</div>
+<div id="security-considerations">
+<section id="section-6">
+      <h2 id="name-security-considerations">
+<a href="#section-6" class="section-number selfRef">6. </a><a href="#name-security-considerations" class="section-name selfRef">Security Considerations</a>
+      </h2>
+<div id="op-security-considerations">
+<section id="section-6.1">
+        <h3 id="name-op-security-considerations">
+<a href="#section-6.1" class="section-number selfRef">6.1. </a><a href="#name-op-security-considerations" class="section-name selfRef">OP Security Considerations</a>
+        </h3>
+<div id="tenant-isolation">
+<section id="section-6.1.1">
+          <h4 id="name-tenant-isolation">
+<a href="#section-6.1.1" class="section-number selfRef">6.1.1. </a><a href="#name-tenant-isolation" class="section-name selfRef">Tenant Isolation</a>
+          </h4>
+<p id="section-6.1.1-1">OPs MUST ensure strict isolation between tenants. An authenticated user from one OP tenant MUST NOT be able to obtain tokens containing a different tenant's identifier. The OP MUST validate that the <code>tenant</code> claim (see Section "ID Token Claims") in issued ID Tokens accurately reflects the tenant context in which the user authenticated.<a href="#section-6.1.1-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="client-tenant-validation">
+<section id="section-6.1.2">
+          <h4 id="name-client-tenant-validation">
+<a href="#section-6.1.2" class="section-number selfRef">6.1.2. </a><a href="#name-client-tenant-validation" class="section-name selfRef">Client Tenant Validation</a>
+          </h4>
+<p id="section-6.1.2-1">When the OP receives a <code>client_tenant</code> authentication request parameter (see Section "Authentication Request Parameters"), the OP SHOULD validate that the value corresponds to a registered RP tenant identifier for the given <code>client_id</code>. If the OP has registered the <code>tenants</code> client registration parameter (see Section "Client Registration Parameters") for the client, the OP SHOULD reject requests where <code>client_tenant</code> is not in the registered list.<a href="#section-6.1.2-1" class="pilcrow">¶</a></p>
+<p id="section-6.1.2-2">Failure to validate the <code>client_tenant</code> parameter could allow an attacker to request tokens for arbitrary RP tenants, potentially bypassing RP tenant-specific policies configured at the OP.<a href="#section-6.1.2-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="subject-identifier-collision">
+<section id="section-6.1.3">
+          <h4 id="name-subject-identifier-collisio">
+<a href="#section-6.1.3" class="section-number selfRef">6.1.3. </a><a href="#name-subject-identifier-collisio" class="section-name selfRef">Subject Identifier Collision</a>
+          </h4>
+<p id="section-6.1.3-1">Multi-tenant OPs MUST ensure that subject identifiers are unambiguous across tenants to prevent account confusion where an RP incorrectly links accounts from different OP tenants.<a href="#section-6.1.3-1" class="pilcrow">¶</a></p>
+<p id="section-6.1.3-2">For multi-tenant OPs using a single issuer (see Appendix A), the OP MUST ensure that subject identifiers are unambiguous across tenants. If the same <code>sub</code> value could exist in multiple OP tenants, the OP MUST include the <code>tenant</code> claim (see Section "ID Token Claims") in the ID Token to enable RPs to correctly identify the account. The combination of <code>iss</code> + <code>tenant</code> + <code>sub</code> (for public subject identifiers) or <code>iss</code> + <code>tenant</code> + <code>client_id</code> + <code>sub</code> (for pairwise subject identifiers) MUST be unique across all tenants (see Appendix A for detailed requirements).<a href="#section-6.1.3-2" class="pilcrow">¶</a></p>
+<p id="section-6.1.3-3">For multi-tenant OPs using tenant-specific issuer identifiers (see Appendix A), the OP MUST ensure that the combination of <code>iss</code> + <code>sub</code> (for public subject identifiers) or <code>iss</code> + <code>client_id</code> + <code>sub</code> (for pairwise subject identifiers) is unique across all tenants. Since each tenant has a different issuer identifier, the OIDC Core requirement that <code>sub</code> is unique within <code>iss</code> already ensures tenant isolation. However, the OP MUST ensure uniqueness across all tenants, regardless of whether a client is shared across tenants or unique per tenant (see Appendix A for detailed requirements).<a href="#section-6.1.3-3" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="token-injection-prevention">
+<section id="section-6.1.4">
+          <h4 id="name-token-injection-prevention">
+<a href="#section-6.1.4" class="section-number selfRef">6.1.4. </a><a href="#name-token-injection-prevention" class="section-name selfRef">Token Injection Prevention</a>
+          </h4>
+<p id="section-6.1.4-1">OPs SHOULD implement measures to prevent token injection attacks where an attacker attempts to replay tokens across tenant boundaries. This includes ensuring that tokens issued for one tenant context cannot be used to authenticate to a different tenant.<a href="#section-6.1.4-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+</div>
+<div id="rp-security-considerations">
+<section id="section-6.2">
+        <h3 id="name-rp-security-considerations">
+<a href="#section-6.2" class="section-number selfRef">6.2. </a><a href="#name-rp-security-considerations" class="section-name selfRef">RP Security Considerations</a>
+        </h3>
+<div id="tenant-claim-validation">
+<section id="section-6.2.1">
+          <h4 id="name-tenant-claim-validation">
+<a href="#section-6.2.1" class="section-number selfRef">6.2.1. </a><a href="#name-tenant-claim-validation" class="section-name selfRef">Tenant Claim Validation</a>
+          </h4>
+<p id="section-6.2.1-1">When an RP expects to receive the <code>tenant</code> claim (see Section "ID Token Claims") (e.g., when authenticating to a multi-tenant OP using a single issuer, as described in Appendix A), the RP MUST validate that the <code>tenant</code> claim is present in the ID Token. If the RP has prior knowledge of the expected tenant (e.g., from a previous authentication or configuration), the RP SHOULD validate that the received <code>tenant</code> claim matches the expected value.<a href="#section-6.2.1-1" class="pilcrow">¶</a></p>
+<p id="section-6.2.1-2">Failure to validate the <code>tenant</code> claim could result in:
+- Account confusion where users from different OP tenants are incorrectly linked
+- Privilege escalation if tenant-specific access controls are bypassed<a href="#section-6.2.1-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="aud-tenant-claim-validation">
+<section id="section-6.2.2">
+          <h4 id="name-aud_tenant-claim-validation">
+<a href="#section-6.2.2" class="section-number selfRef">6.2.2. </a><a href="#name-aud_tenant-claim-validation" class="section-name selfRef">aud_tenant Claim Validation</a>
+          </h4>
+<p id="section-6.2.2-1">When an RP sends the <code>client_tenant</code> authentication request parameter (see Section "Authentication Request Parameters"), the RP MUST validate that the returned <code>aud_tenant</code> claim (see Section "ID Token Claims") matches the value sent in the request. If the <code>aud_tenant</code> claim is missing or contains a different value, the RP MUST reject the ID Token.<a href="#section-6.2.2-1" class="pilcrow">¶</a></p>
+<p id="section-6.2.2-2">This validation prevents an attacker from obtaining a token intended for one RP tenant and using it to authenticate to a different RP tenant. See Appendix A for details on how the <code>client_tenant</code> parameter relates to the <code>aud_tenant</code> claim.<a href="#section-6.2.2-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="account-identifier-uniqueness">
+<section id="section-6.2.3">
+          <h4 id="name-account-identifier-uniquene">
+<a href="#section-6.2.3" class="section-number selfRef">6.2.3. </a><a href="#name-account-identifier-uniquene" class="section-name selfRef">Account Identifier Uniqueness</a>
+          </h4>
+<p id="section-6.2.3-1">RPs MUST use the complete set of identifying claims when linking accounts:
+- For multi-tenant OPs using a single issuer (see Appendix A): <code>iss</code> + <code>tenant</code> (see Section "ID Token Claims") + <code>sub</code>
+- For multi-tenant OPs using tenant-specific issuers (see Appendix A): <code>iss</code> + <code>sub</code>
+- For multi-tenant RPs with shared <code>client_id</code> (see Appendix A): <code>aud</code> + <code>aud_tenant</code> (see Section "ID Token Claims") + <code>aud_sub</code> (see Section "ID Token Claims") (when present)<a href="#section-6.2.3-1" class="pilcrow">¶</a></p>
+<p id="section-6.2.3-2">Using only a subset of these claims (e.g., only <code>sub</code>) could result in incorrectly linking accounts from different tenants.<a href="#section-6.2.3-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="cross-tenant-request-forgery">
+<section id="section-6.2.4">
+          <h4 id="name-cross-tenant-request-forger">
+<a href="#section-6.2.4" class="section-number selfRef">6.2.4. </a><a href="#name-cross-tenant-request-forger" class="section-name selfRef">Cross-Tenant Request Forgery</a>
+          </h4>
+<p id="section-6.2.4-1">Multi-tenant RPs MUST ensure that authentication responses are processed in the correct tenant context. When using the <code>state</code> parameter or session context for tenant routing, the RP MUST validate that the response is processed by the same tenant that initiated the request. Failure to do so could allow an attacker to initiate authentication in one RP tenant and have the response processed in a different RP tenant.<a href="#section-6.2.4-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+</div>
+</section>
+</div>
+<div id="privacy-considerations">
+<section id="section-7">
+      <h2 id="name-privacy-considerations">
+<a href="#section-7" class="section-number selfRef">7. </a><a href="#name-privacy-considerations" class="section-name selfRef">Privacy Considerations</a>
+      </h2>
+<p id="section-7-1"><em>To be completed.</em><a href="#section-7-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="iana-considerations">
+<section id="section-8">
+      <h2 id="name-iana-considerations">
+<a href="#section-8" class="section-number selfRef">8. </a><a href="#name-iana-considerations" class="section-name selfRef">IANA Considerations</a>
+      </h2>
+<p id="section-8-1"><em>To be completed.</em><a href="#section-8-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="references">
+<section id="section-9">
+      <h2 id="name-references">
+<a href="#section-9" class="section-number selfRef">9. </a><a href="#name-references" class="section-name selfRef">References</a>
+      </h2>
+<div id="normative-references">
+<section id="section-9.1">
+        <h3 id="name-normative-references">
+<a href="#section-9.1" class="section-number selfRef">9.1. </a><a href="#name-normative-references" class="section-name selfRef">Normative References</a>
+        </h3>
+<ul class="compact">
+<li class="compact" id="section-9.1-1.1">
+            <strong>[RFC2119]</strong> Bradner, S. "Key words for use in RFCs to Indicate Requirement Levels," <em>RFC 2119</em>, March 1997.<a href="#section-9.1-1.1" class="pilcrow">¶</a>
+</li>
+          <li class="compact" id="section-9.1-1.2">
+            <strong>[OpenID Connect Core 1.0]</strong> – "OpenID Connect Core 1.0 incorporating errata set 2," available at <a href="https://openid.net/specs/openid-connect-core-1_0.html">https://openid.net/specs/openid-connect-core-1_0.html</a>.<a href="#section-9.1-1.2" class="pilcrow">¶</a>
+</li>
+          <li class="compact" id="section-9.1-1.3">
+            <strong>[OpenID Connect Discovery 1.0]</strong> – "OpenID Connect Discovery 1.0 incorporating errata set 2," available at <a href="https://openid.net/specs/openid-connect-discovery-1_0.html">https://openid.net/specs/openid-connect-discovery-1_0.html</a>.<a href="#section-9.1-1.3" class="pilcrow">¶</a>
+</li>
+          <li class="compact" id="section-9.1-1.4">
+            <strong>[OpenID Connect Dynamic Client Registration 1.0]</strong> – "OpenID Connect Dynamic Client Registration 1.0 incorporating errata set 2," available at <a href="https://openid.net/specs/openid-connect-registration-1_0.html">https://openid.net/specs/openid-connect-registration-1_0.html</a>.<a href="#section-9.1-1.4" class="pilcrow">¶</a>
+</li>
+        </ul>
+</section>
+</div>
+<div id="informative-references">
+<section id="section-9.2">
+        <h3 id="name-informative-references">
+<a href="#section-9.2" class="section-number selfRef">9.2. </a><a href="#name-informative-references" class="section-name selfRef">Informative References</a>
+        </h3>
+<ul class="compact">
+<li class="compact" id="section-9.2-1.1">
+            <strong>IANA JSON Web Token Claims Registry</strong>, available at <a href="https://www.iana.org/assignments/jwt/jwt.xhtml">https://www.iana.org/assignments/jwt/jwt.xhtml</a>.<a href="#section-9.2-1.1" class="pilcrow">¶</a>
+</li>
+          <li class="compact" id="section-9.2-1.2">
+            <strong>IANA OAuth Parameters</strong>, available at <a href="https://www.iana.org/assignments/oauth-parameters/oauth-parameters.xhtml#client-metadata">https://www.iana.org/assignments/oauth-parameters/oauth-parameters.xhtml#client-metadata</a>.<a href="#section-9.2-1.2" class="pilcrow">¶</a>
+</li>
+        </ul>
+</section>
+</div>
+</section>
+</div>
+<div id="enterprise-tenancy-models">
+<section id="appendix-A">
+      <h2 id="name-enterprise-tenancy-models">
+<a href="#appendix-A" class="section-number selfRef">Appendix A. </a><a href="#name-enterprise-tenancy-models" class="section-name selfRef">Enterprise Tenancy Models</a>
+      </h2>
+<p id="appendix-A-1">This appendix is non-normative.<a href="#appendix-A-1" class="pilcrow">¶</a></p>
+<p id="appendix-A-2">This appendix explains the relationships between issuer, client, and tenant for an OpenID Provider (OP) and Relying Party (RP). Understanding these models is helpful for correctly implementing the claims and parameters defined in this specification.<a href="#appendix-A-2" class="pilcrow">¶</a></p>
+<p id="appendix-A-3">The following diagram illustrates the relationship between OP tenants, RP tenants, and accounts:<a href="#appendix-A-3" class="pilcrow">¶</a></p>
+<div class="alignLeft art-text artwork" id="appendix-A-4">
+<pre>┌─────────────────────────────────────────────────────────────┐
+│                  OpenID Provider (OP)                       │
+│                                                             │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐       │
+│  │ OP Tenant A  │  │ OP Tenant B  │  │ OP Tenant C  │       │
+│  │              │  │              │  │              │       │
+│  │ ┌──────────┐ │  │ ┌──────────┐ │  │ ┌──────────┐ │       │
+│  │ │ Account 1│ │  │ │ Account 1│ │  │ │ Account 1│ │       │
+│  │ │ Account 2│ │  │ │ Account 2│ │  │ │ Account 2│ │       │
+│  │ └──────────┘ │  │ └──────────┘ │  │ └──────────┘ │       │
+│  └──────────────┘  └──────────────┘  └──────────────┘       │
+│                                                             │
+│  Identified by: `iss` + `tenant` (single issuer model)      │
+│  or by: `iss` alone (tenant-specific issuer model)          │
+└─────────────────────────────────────────────────────────────┘
+                            │
+                            │ Authentication
+                            │
+┌─────────────────────────────────────────────────────────────┐
+│                  Relying Party (RP)                         │
+│                                                             │
+│  ┌──────────────┐  ┌──────────────┐                         │
+│  │ RP Tenant X  │  │ RP Tenant Y  │                         │
+│  │              │  │              │                         │
+│  │ ┌──────────┐ │  │ ┌──────────┐ │                         │
+│  │ │ Account 1│ │  │ │ Account 1│ │                         │
+│  │ │ Account 2│ │  │ │ Account 2│ │                         │
+│  │ └──────────┘ │  │ └──────────┘ │                         │
+│  └──────────────┘  └──────────────┘                         │
+│                                                             │
+│  Identified by: `aud` (unique client per tenant)            │
+│  or by: `aud` + `aud_tenant` (shared client model)          │
+└─────────────────────────────────────────────────────────────┘
+</pre><a href="#appendix-A-4" class="pilcrow">¶</a>
+</div>
+<div id="op-tenancy">
+<section id="appendix-A.1">
+        <h3 id="name-op-tenancy">
+<a href="#appendix-A.1" class="section-number selfRef">A.1. </a><a href="#name-op-tenancy" class="section-name selfRef">OP Tenancy</a>
+        </h3>
+<p id="appendix-A.1-1">An OP can have a single-tenant issuer or a multi-tenant issuer:<a href="#appendix-A.1-1" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="appendix-A.1-2.1">
+            <p id="appendix-A.1-2.1.1"><strong>Single-tenant OP</strong>: The OP has a single tenant. All accounts are associated with this single tenant.<a href="#appendix-A.1-2.1.1" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="appendix-A.1-2.1.2.1">
+                <p id="appendix-A.1-2.1.2.1.1"><strong>Issuer Configuration</strong>: The issuer identifier (<code>iss</code>) uniquely identifies the OP. The OP has a single OP metadata endpoint and signing keys.<a href="#appendix-A.1-2.1.2.1.1" class="pilcrow">¶</a></p>
+</li>
+              <li class="normal" id="appendix-A.1-2.1.2.2">
+                <p id="appendix-A.1-2.1.2.2.1"><strong>Subject Identifier Uniqueness</strong>:<a href="#appendix-A.1-2.1.2.2.1" class="pilcrow">¶</a></p>
+<ul class="compact normal">
+<li class="compact normal" id="appendix-A.1-2.1.2.2.2.1">If the OP uses <code>pairwise</code> subject identifiers, the <code>sub</code> value for the same user will differ across different <code>client_id</code> values.<a href="#appendix-A.1-2.1.2.2.2.1" class="pilcrow">¶</a>
+</li>
+                  <li class="compact normal" id="appendix-A.1-2.1.2.2.2.2">If the OP uses <code>public</code> subject identifiers, the <code>sub</code> value will be the same across all RPs/clients.<a href="#appendix-A.1-2.1.2.2.2.2" class="pilcrow">¶</a>
+</li>
+                </ul>
+</li>
+            </ul>
+</li>
+        </ul>
+<p id="appendix-A.1-3">For example:<a href="#appendix-A.1-3" class="pilcrow">¶</a></p>
+<div class="lang-json sourcecode" id="appendix-A.1-4">
+<pre>  {
+    "iss": "https://idp.example.com",
+    "sub": "user123"
+  }
+</pre><a href="#appendix-A.1-4" class="pilcrow">¶</a>
+</div>
+<ul class="normal">
+<li class="normal" id="appendix-A.1-5.1">
+            <p id="appendix-A.1-5.1.1"><strong>Multi-tenant OP</strong>: The OP has multiple tenants. Multi-tenant OPs may use a single issuer identifier for all tenants, or tenant-specific issuer identifiers:<a href="#appendix-A.1-5.1.1" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="appendix-A.1-5.1.2.1">
+                <p id="appendix-A.1-5.1.2.1.1"><strong>Single issuer for all tenants</strong>: The OP uses one issuer identifier for all tenants, and the <code>tenant</code> claim (see Section "ID Token Claims") distinguishes between tenants.<a href="#appendix-A.1-5.1.2.1.1" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="appendix-A.1-5.1.2.1.2.1">
+                    <p id="appendix-A.1-5.1.2.1.2.1.1"><strong>Issuer Configuration</strong>: All tenants share the same issuer identifier (<code>iss</code>), OP metadata endpoint, and signing keys.<a href="#appendix-A.1-5.1.2.1.2.1.1" class="pilcrow">¶</a></p>
+</li>
+                  <li class="normal" id="appendix-A.1-5.1.2.1.2.2">
+                    <p id="appendix-A.1-5.1.2.1.2.2.1"><strong>Subject Identifier Uniqueness</strong>:<a href="#appendix-A.1-5.1.2.1.2.2.1" class="pilcrow">¶</a></p>
+<ul class="compact normal">
+<li class="compact normal" id="appendix-A.1-5.1.2.1.2.2.2.1">The combination of <code>iss</code> (issuer identifier), <code>tenant</code> (OP tenant identifier), and <code>sub</code> (subject identifier) MUST be unique across all tenants. This ensures that a subject identifier is unambiguous within the context of the OP, even when the same <code>sub</code> value might exist in different OP tenants.<a href="#appendix-A.1-5.1.2.1.2.2.2.1" class="pilcrow">¶</a>
+</li>
+                      <li class="compact normal" id="appendix-A.1-5.1.2.1.2.2.2.2">If the OP uses <code>pairwise</code> subject identifiers, the <code>sub</code> value for the same user MUST differ across different <code>client_id</code> values, but the same user MAY have the same <code>sub</code> value for the same <code>client_id</code> regardless of which OP tenant they authenticate to.  The OP is not required to have unique <code>pairwise</code> subject identifiers for clients that are shared across tenants per [OpenID Connect Core 1.0] Section 8.1. The <code>tenant</code> claim SHOULD be included in the uniqueness requirement (<code>iss</code> + <code>tenant</code> + <code>sub</code>) to disambiguate subjects across tenants.<a href="#appendix-A.1-5.1.2.1.2.2.2.2" class="pilcrow">¶</a>
+</li>
+                      <li class="compact normal" id="appendix-A.1-5.1.2.1.2.2.2.3">If the OP uses <code>public</code> subject identifiers, the <code>sub</code> value MUST be the same across all RPs/clients and all OP tenants. The <code>tenant</code> claim MUST be included in the uniqueness requirement (<code>iss</code> + <code>tenant</code> + <code>sub</code>) to disambiguate subjects across tenants.<a href="#appendix-A.1-5.1.2.1.2.2.2.3" class="pilcrow">¶</a>
+</li>
+                    </ul>
+</li>
+                </ul>
+</li>
+            </ul>
+<p id="appendix-A.1-5.1.3">For example:<a href="#appendix-A.1-5.1.3" class="pilcrow">¶</a></p>
+<p id="appendix-A.1-5.1.4">Acme Corporation OP Tenant<a href="#appendix-A.1-5.1.4" class="pilcrow">¶</a></p>
+<div class="lang-json sourcecode" id="appendix-A.1-5.1.5">
+<pre>{
+  "iss": "https://idp.example.com",
+  "tenant": "acme-corp",
+  "sub": "user123"
+}
+</pre><a href="#appendix-A.1-5.1.5" class="pilcrow">¶</a>
+</div>
+<p id="appendix-A.1-5.1.6">Widgets Inc. OP Tenant<a href="#appendix-A.1-5.1.6" class="pilcrow">¶</a></p>
+<div class="lang-json sourcecode" id="appendix-A.1-5.1.7">
+<pre>{
+  "iss": "https://idp.example.com",
+  "tenant": "widgets-inc",
+  "sub": "user456"
+}
+</pre><a href="#appendix-A.1-5.1.7" class="pilcrow">¶</a>
+</div>
+<ul class="normal">
+<li class="normal" id="appendix-A.1-5.1.8.1">
+                <p id="appendix-A.1-5.1.8.1.1"><strong>Tenant-specific issuer identifiers</strong>: The OP uses different issuer identifiers per tenant.<a href="#appendix-A.1-5.1.8.1.1" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="appendix-A.1-5.1.8.1.2.1">
+                    <p id="appendix-A.1-5.1.8.1.2.1.1"><strong>Issuer Configuration</strong>: Each tenant has its own issuer identifier (<code>iss</code>), OP metadata endpoint, and signing keys. Each issuer identifier MUST be a valid URL per [OpenID Connect Core 1.0] Section 2.<a href="#appendix-A.1-5.1.8.1.2.1.1" class="pilcrow">¶</a></p>
+</li>
+                  <li class="normal" id="appendix-A.1-5.1.8.1.2.2">
+                    <p id="appendix-A.1-5.1.8.1.2.2.1"><strong>Subject Identifier Uniqueness</strong>:<a href="#appendix-A.1-5.1.8.1.2.2.1" class="pilcrow">¶</a></p>
+<ul class="compact normal">
+<li class="compact normal" id="appendix-A.1-5.1.8.1.2.2.2.1">The combination of <code>iss</code> (issuer identifier) and <code>sub</code> (subject identifier) MUST be unique. Since each issuer identifier identifies a specific tenant, the OIDC Core requirement that <code>sub</code> is unique within <code>iss</code> already ensures tenant isolation.<a href="#appendix-A.1-5.1.8.1.2.2.2.1" class="pilcrow">¶</a>
+</li>
+                      <li class="compact normal" id="appendix-A.1-5.1.8.1.2.2.2.2">If the OP uses <code>pairwise</code> subject identifiers, the <code>sub</code> value for the same user MUST differ across different <code>client_id</code> values within each tenant. The combination of <code>iss</code> + <code>client_id</code> + <code>sub</code> MUST be unique across all tenants, regardless of whether a client is shared across tenants or unique per tenant, since each tenant has a different issuer identifier.<a href="#appendix-A.1-5.1.8.1.2.2.2.2" class="pilcrow">¶</a>
+</li>
+                      <li class="compact normal" id="appendix-A.1-5.1.8.1.2.2.2.3">If the OP uses <code>public</code> subject identifiers, the <code>sub</code> value MUST be the same across all RPs/clients within each tenant. The <code>sub</code> value MAY be the same across tenants (a global <code>sub</code>), but the combination of <code>iss</code> + <code>sub</code> MUST be unique across all tenants since each tenant has a different issuer identifier.<a href="#appendix-A.1-5.1.8.1.2.2.2.3" class="pilcrow">¶</a>
+</li>
+                    </ul>
+</li>
+                </ul>
+</li>
+            </ul>
+<p id="appendix-A.1-5.1.9">For example:<a href="#appendix-A.1-5.1.9" class="pilcrow">¶</a></p>
+<p id="appendix-A.1-5.1.10">Acme Corporation OP Tenant<a href="#appendix-A.1-5.1.10" class="pilcrow">¶</a></p>
+<div class="lang-json sourcecode" id="appendix-A.1-5.1.11">
+<pre>{
+  "iss": "https://acme-corp.idp.example.com",
+  "sub": "user123"
+}
+</pre><a href="#appendix-A.1-5.1.11" class="pilcrow">¶</a>
+</div>
+<p id="appendix-A.1-5.1.12">Widgets Inc. OP Tenant<a href="#appendix-A.1-5.1.12" class="pilcrow">¶</a></p>
+<div class="lang-json sourcecode" id="appendix-A.1-5.1.13">
+<pre>{
+  "iss": "https://widgets-inc.idp.example.com",
+  "sub": "user456"
+}
+</pre><a href="#appendix-A.1-5.1.13" class="pilcrow">¶</a>
+</div>
+</li>
+        </ul>
+<p id="appendix-A.1-6">The following table summarizes OP tenancy models:<a href="#appendix-A.1-6" class="pilcrow">¶</a></p>
+<table class="center" id="table-1">
+          <caption><a href="#table-1" class="selfRef">Table 1</a></caption>
+<thead>
+            <tr>
+              <th class="text-left" rowspan="1" colspan="1">Model</th>
+              <th class="text-left" rowspan="1" colspan="1">Issuer Configuration</th>
+              <th class="text-left" rowspan="1" colspan="1">Uniqueness Requirement</th>
+              <th class="text-left" rowspan="1" colspan="1">Tenant Identification</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">Single-tenant OP</td>
+              <td class="text-left" rowspan="1" colspan="1">Single <code>iss</code>, single metadata endpoint, single signing keys</td>
+              <td class="text-left" rowspan="1" colspan="1">
+                <code>public</code>: <code>sub</code> unique within <code>iss</code><br>
+                <code>pairwise</code>: <code>iss</code> + <code>client_id</code> + <code>sub</code> unique</td>
+              <td class="text-left" rowspan="1" colspan="1">Not applicable</td>
+            </tr>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">Multi-tenant OP (single issuer)</td>
+              <td class="text-left" rowspan="1" colspan="1">Single <code>iss</code> shared across tenants, single metadata endpoint, single signing keys</td>
+              <td class="text-left" rowspan="1" colspan="1">
+                <code>public</code>: <code>iss</code> + <code>tenant</code> + <code>sub</code> unique<br>
+                <code>pairwise</code>: <code>iss</code> + <code>tenant</code> + <code>client_id</code> + <code>sub</code> unique</td>
+              <td class="text-left" rowspan="1" colspan="1">
+                <code>tenant</code> claim in ID Token (see Section "ID Token Claims")</td>
+            </tr>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">Multi-tenant OP (tenant-specific issuers)</td>
+              <td class="text-left" rowspan="1" colspan="1">Each tenant has own <code>iss</code>, metadata endpoint, and signing keys</td>
+              <td class="text-left" rowspan="1" colspan="1">
+                <code>public</code>: <code>iss</code> + <code>sub</code> unique (per tenant)<br>
+                <code>pairwise</code>: <code>iss</code> + <code>client_id</code> + <code>sub</code> unique (per tenant)</td>
+              <td class="text-left" rowspan="1" colspan="1">
+                <code>iss</code> value identifies tenant</td>
+            </tr>
+          </tbody>
+        </table>
+<ul class="compact">
+<li class="compact" id="appendix-A.1-8.1">
+            <strong>Discovery</strong>: If an OP publishes support for the <code>tenant</code> claim in the <code>claims_supported</code> metadata parameter (see [OpenID Connect Discovery 1.0]), then RPs SHOULD assume that the issuer supports multiple tenants and SHOULD expect the <code>tenant</code> claim to be present in ID Tokens.<a href="#appendix-A.1-8.1" class="pilcrow">¶</a>
+</li>
+        </ul>
+</section>
+</div>
+<div id="op-tenant-communication">
+<section id="appendix-A.2">
+        <h3 id="name-op-tenant-communication">
+<a href="#appendix-A.2" class="section-number selfRef">A.2. </a><a href="#name-op-tenant-communication" class="section-name selfRef">OP Tenant Communication</a>
+        </h3>
+<p id="appendix-A.2-1">When the OP uses tenant-specific issuer identifiers, the RP authenticates to the appropriate issuer endpoint (e.g., <code>https://acme-corp.idp.example.com</code>), and the tenant is identified by the issuer identifier itself. In that model, OP tenant communication is not required.<a href="#appendix-A.2-1" class="pilcrow">¶</a></p>
+<p id="appendix-A.2-2">The following applies only to multi-tenant OPs that use a single issuer for all tenants. For such OPs, the RP MAY specify which OP tenant it wants the user to authenticate to using one of the following mechanisms:<a href="#appendix-A.2-2" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="appendix-A.2-3.1">
+            <p id="appendix-A.2-3.1.1"><strong><code>tenant</code> parameter</strong>: The RP includes the <code>tenant</code> parameter in the authentication request with the OP tenant identifier value (e.g., <code>tenant=acme-corp</code>). When the OP receives this parameter, it SHOULD include the <code>tenant</code> claim in the ID Token with the same value. This is RECOMMENDED for RPs that know which <code>tenant</code> to make an authentication request to. See Section "Authentication Request Parameters" for details.<a href="#appendix-A.2-3.1.1" class="pilcrow">¶</a></p>
+</li>
+          <li class="normal" id="appendix-A.2-3.2">
+            <p id="appendix-A.2-3.2.1"><strong><code>domain_hint</code> parameter</strong>: The RP includes the <code>domain_hint</code> parameter with a domain name or email domain (e.g., <code>example.com</code>) that helps the OP identify the appropriate tenant. This is a user experience hint and is not guaranteed to uniquely identify a tenant. When both <code>tenant</code> and <code>domain_hint</code> are present, the <code>tenant</code> parameter takes precedence. If the OP cannot uniquely identify the tenant from <code>domain_hint</code> alone, the OP's tenant selection behavior is implementation-dependent. See Section "Authentication Request Parameters" for details.<a href="#appendix-A.2-3.2.1" class="pilcrow">¶</a></p>
+</li>
+        </ul>
+<p id="appendix-A.2-4">When the OP tenant is not specified by the RP (neither <code>tenant</code> nor <code>domain_hint</code> is provided, or <code>domain_hint</code> does not uniquely identify a tenant), the OP MAY:
+- Provide a selector to allow the end-user to pick the tenant during authentication
+- Default to a specific tenant for the <code>client_id</code> and/or <code>login_hint</code>
+- Reject the request with an <code>invalid_request</code> error<a href="#appendix-A.2-4" class="pilcrow">¶</a></p>
+<p id="appendix-A.2-5">The following diagram illustrates OP tenant communication flow:<a href="#appendix-A.2-5" class="pilcrow">¶</a></p>
+<div class="alignLeft art-text artwork" id="appendix-A.2-6">
+<pre>┌─────────────────────┐                    ┌─────────────────────┐
+│         RP          │                    │         OP          │
+│                     │                    │                     │
+│ 1. RP determines    │                    │                     │
+│    desired OP       │                    │                     │
+│    tenant           │                    │                     │
+│    (from user       │                    │                     │
+│    input, config,   │                    │                     │
+│    etc.)            │                    │                     │
+│                     │                    │                     │
+│ 2. Authentication   │                    │                     │
+│    Request          │                    │                     │
+│    ├─ tenant=acme-  │                    │                     │
+│    │  corp          │                    │                     │
+│    │  (explicit)    │                    │                     │
+│    └─ OR            │                    │                     │
+│       domain_hint=  │                    │                     │
+│       acme.com      │                    │                     │
+│       (hint)        │                    │                     │
+│         │───────────────────────────────&gt;│                     │
+│         │                                │                     │
+│         │                                │ 3. OP resolves      │
+│         │                                │    tenant context   │
+│         │                                │                     │
+│         │                                │ 4. User auth        │
+│         │                                │                     │
+│         │ 5. ID Token                    │                     │
+│         │    └─ tenant: "acme-corp"      │                     │
+│         │&lt;───────────────────────────────│                     │
+│         │                                │                     │
+│ 6. RP validates     │                    │                     │
+│    tenant claim     │                    │                     │
+│    matches expected │                    │                     │
+│    tenant           │                    │                     │
+└─────────────────────┘                    └─────────────────────┘
+</pre><a href="#appendix-A.2-6" class="pilcrow">¶</a>
+</div>
+</section>
+</div>
+<div id="rp-tenancy">
+<section id="appendix-A.3">
+        <h3 id="name-rp-tenancy">
+<a href="#appendix-A.3" class="section-number selfRef">A.3. </a><a href="#name-rp-tenancy" class="section-name selfRef">RP Tenancy</a>
+        </h3>
+<p id="appendix-A.3-1">An RP can be single-tenant or multi-tenant:<a href="#appendix-A.3-1" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="appendix-A.3-2.1">
+            <p id="appendix-A.3-2.1.1"><strong>Single-tenant RP</strong>: The RP has a single tenant. All accounts are associated with this single tenant.<a href="#appendix-A.3-2.1.1" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="appendix-A.3-2.1.2.1">
+                <p id="appendix-A.3-2.1.2.1.1"><strong>Registration</strong>: The RP registers a single <code>client_id</code> with the OP issuer.<a href="#appendix-A.3-2.1.2.1.1" class="pilcrow">¶</a></p>
+</li>
+              <li class="normal" id="appendix-A.3-2.1.2.2">
+                <p id="appendix-A.3-2.1.2.2.1"><strong>Account Identifier Uniqueness</strong>: Account identifiers (such as <code>aud_sub</code> if present) MUST be unique within the context of that <code>client_id</code>.<a href="#appendix-A.3-2.1.2.2.1" class="pilcrow">¶</a></p>
+</li>
+            </ul>
+</li>
+        </ul>
+<p id="appendix-A.3-3">For example:<a href="#appendix-A.3-3" class="pilcrow">¶</a></p>
+<div class="lang-json sourcecode" id="appendix-A.3-4">
+<pre>  {
+    "iss": "https://idp.example.com",
+    "sub": "user123",
+    "aud": "rp-single-tenant-xyz",
+    "aud_sub": "rp-account-123"
+  }
+</pre><a href="#appendix-A.3-4" class="pilcrow">¶</a>
+</div>
+<ul class="normal">
+<li class="normal" id="appendix-A.3-5.1">
+            <p id="appendix-A.3-5.1.1"><strong>Multi-tenant RP</strong>: The RP has multiple tenants. Each tenant represents a distinct organizational or administrative boundary within the RP. Accounts are specific to the RP tenant. When an RP is multi-tenant, it needs to structure its client registration with the OP so that the OP can identify which RP tenant is making an authentication request. Multi-tenant RPs can use one of the following approaches:<a href="#appendix-A.3-5.1.1" class="pilcrow">¶</a></p>
+<ul class="compact normal">
+<li class="compact normal" id="appendix-A.3-5.1.2.1">
+                <p id="appendix-A.3-5.1.2.1.1"><strong>Unique Client per Tenant</strong>: Each RP tenant has its own unique <code>client_id</code> registered with the OP issuer.<a href="#appendix-A.3-5.1.2.1.1" class="pilcrow">¶</a></p>
+<ul class="compact normal">
+<li class="compact normal" id="appendix-A.3-5.1.2.1.2.1">
+                    <strong>Registration</strong>: Each RP tenant registers its own unique <code>client_id</code> with the OP issuer.<a href="#appendix-A.3-5.1.2.1.2.1" class="pilcrow">¶</a>
+</li>
+                  <li class="compact normal" id="appendix-A.3-5.1.2.1.2.2">
+                    <strong>Account Identifier Uniqueness</strong>: Account identifiers (such as <code>aud_sub</code> if present) MUST be unique within the context of that <code>client_id</code>.<a href="#appendix-A.3-5.1.2.1.2.2" class="pilcrow">¶</a>
+</li>
+                </ul>
+</li>
+            </ul>
+<p id="appendix-A.3-5.1.3">For example:
+ - RP tenant "Acme Corp" uses <code>client_id</code>: <code>rp-acme-corp-12345</code><a href="#appendix-A.3-5.1.3" class="pilcrow">¶</a></p>
+<div class="lang-json sourcecode" id="appendix-A.3-5.1.4">
+<pre>  {
+    "iss": "https://idp.example.com",
+    "sub": "user123",
+    "aud": "rp-acme-corp-12345",
+    "aud_sub": "acme-account-456"
+  }
+</pre><a href="#appendix-A.3-5.1.4" class="pilcrow">¶</a>
+</div>
+<ul class="normal">
+<li class="normal" id="appendix-A.3-5.1.5.1">
+                <p id="appendix-A.3-5.1.5.1.1">RP tenant "Widgets Inc" uses <code>client_id</code>: <code>rp-widgets-inc-67890</code><a href="#appendix-A.3-5.1.5.1.1" class="pilcrow">¶</a></p>
+<div class="lang-json sourcecode" id="appendix-A.3-5.1.5.1.2">
+<pre>{
+"iss": "https://idp.example.com",
+"sub": "user123",
+"aud": "rp-widgets-inc-67890",
+"aud_sub": "widgets-account-789"
+}
+</pre><a href="#appendix-A.3-5.1.5.1.2" class="pilcrow">¶</a>
+</div>
+</li>
+              <li class="normal" id="appendix-A.3-5.1.5.2">
+                <p id="appendix-A.3-5.1.5.2.1"><strong>Shared Client for all Tenants</strong>: Multiple RP tenants share a single <code>client_id</code> registered with the OP.<a href="#appendix-A.3-5.1.5.2.1" class="pilcrow">¶</a></p>
+<ul class="compact normal">
+<li class="compact normal" id="appendix-A.3-5.1.5.2.2.1">
+                    <strong>Registration</strong>: All RP tenants share a single <code>client_id</code> registered with the OP. The RP MAY register the <code>tenants</code> client registration parameter (see Section "Client Registration Parameters") as a JSON array of strings containing the RP tenant identifiers.<a href="#appendix-A.3-5.1.5.2.2.1" class="pilcrow">¶</a>
+</li>
+                  <li class="compact normal" id="appendix-A.3-5.1.5.2.2.2">
+                    <strong>Account Identifier Uniqueness</strong>: When both <code>aud_tenant</code> and <code>aud_sub</code> are present, their combination MUST be unique for a given <code>aud</code> (client identifier) within the RP. This ensures that account identifiers are unambiguous within the context of the RP, even when the same <code>aud_sub</code> value might exist in different RP tenants.<a href="#appendix-A.3-5.1.5.2.2.2" class="pilcrow">¶</a>
+</li>
+                </ul>
+</li>
+            </ul>
+<p id="appendix-A.3-5.1.6">For example:
+ - All RP tenants share <code>client_id</code>: <code>rp-shared-abcde</code>
+ - RP tenant "Acme Corp" is identified by the <code>aud_tenant</code> claim in the ID Token:<a href="#appendix-A.3-5.1.6" class="pilcrow">¶</a></p>
+<div class="lang-json sourcecode" id="appendix-A.3-5.1.7">
+<pre>  {
+    "iss": "https://idp.example.com",
+    "sub": "user123",
+    "aud": "rp-shared-abcde",
+    "aud_tenant": "acme-corp-tenant-id"
+  }
+</pre><a href="#appendix-A.3-5.1.7" class="pilcrow">¶</a>
+</div>
+<ul class="compact normal">
+<li class="compact normal" id="appendix-A.3-5.1.8.1">RP tenant "Widgets Inc" is identified by the <code>aud_tenant</code> claim in the ID Token:<a href="#appendix-A.3-5.1.8.1" class="pilcrow">¶</a>
+</li>
+            </ul>
+<div class="lang-json sourcecode" id="appendix-A.3-5.1.9">
+<pre>  {
+    "iss": "https://idp.example.com",
+    "sub": "user456",
+    "aud": "rp-shared-abcde",
+    "aud_tenant": "widgets-inc-tenant-id"
+  }
+</pre><a href="#appendix-A.3-5.1.9" class="pilcrow">¶</a>
+</div>
+</li>
+        </ul>
+<p id="appendix-A.3-6">The following table summarizes RP tenancy models:<a href="#appendix-A.3-6" class="pilcrow">¶</a></p>
+<table class="center" id="table-2">
+          <caption><a href="#table-2" class="selfRef">Table 2</a></caption>
+<thead>
+            <tr>
+              <th class="text-left" rowspan="1" colspan="1">Model</th>
+              <th class="text-left" rowspan="1" colspan="1">Registration</th>
+              <th class="text-left" rowspan="1" colspan="1">Account Identifier Uniqueness</th>
+              <th class="text-left" rowspan="1" colspan="1">Tenant Identification</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">Single-tenant RP</td>
+              <td class="text-left" rowspan="1" colspan="1">Single <code>client_id</code> registered with OP issuer</td>
+              <td class="text-left" rowspan="1" colspan="1">
+                <code>aud_sub</code> unique within <code>client_id</code>
+</td>
+              <td class="text-left" rowspan="1" colspan="1">Not applicable</td>
+            </tr>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">Multi-tenant RP (unique client per tenant)</td>
+              <td class="text-left" rowspan="1" colspan="1">Each tenant has own <code>client_id</code> registered with OP issuer</td>
+              <td class="text-left" rowspan="1" colspan="1">
+                <code>aud_sub</code> unique within <code>client_id</code>
+</td>
+              <td class="text-left" rowspan="1" colspan="1">
+                <code>aud</code> identifies tenant</td>
+            </tr>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">Multi-tenant RP (shared client)</td>
+              <td class="text-left" rowspan="1" colspan="1">Single <code>client_id</code> shared across tenants, <code>tenants</code> parameter MAY be registered</td>
+              <td class="text-left" rowspan="1" colspan="1">
+                <code>aud_tenant</code> + <code>aud_sub</code> unique within <code>aud</code>
+</td>
+              <td class="text-left" rowspan="1" colspan="1">
+                <code>aud</code> + <code>aud_tenant</code> claim in ID Token (see Section "ID Token Claims")</td>
+            </tr>
+          </tbody>
+        </table>
+<ul class="compact">
+<li class="compact" id="appendix-A.3-8.1">
+            <strong>Discovery</strong>: If an RP supports multiple tenants and registers the <code>tenants</code> client registration parameter for the client, then OPs SHOULD assume the RP is multi-tenant.<a href="#appendix-A.3-8.1" class="pilcrow">¶</a>
+</li>
+        </ul>
+</section>
+</div>
+<div id="rp-tenant-communication">
+<section id="appendix-A.4">
+        <h3 id="name-rp-tenant-communication">
+<a href="#appendix-A.4" class="section-number selfRef">A.4. </a><a href="#name-rp-tenant-communication" class="section-name selfRef">RP Tenant Communication</a>
+        </h3>
+<p id="appendix-A.4-1">When an RP is multi-tenant and uses a shared <code>client_id</code>, the RP MAY communicate its tenant identifier to the OP, but is not required to do so. If the OP knows the RP tenant identifier, it SHOULD include it in the <code>aud_tenant</code> claim of the ID Token (see Section "ID Token Claims").<a href="#appendix-A.4-1" class="pilcrow">¶</a></p>
+<p id="appendix-A.4-2">The RP can communicate its tenant identifier using one of the following mechanisms:<a href="#appendix-A.4-2" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="appendix-A.4-3.1">
+            <p id="appendix-A.4-3.1.1"><strong><code>client_tenant</code> authentication request parameter</strong> (RECOMMENDED): The RP includes the <code>client_tenant</code> parameter in the authentication request with its tenant identifier value. This is explicit and unambiguous, allowing the OP to include the <code>aud_tenant</code> claim in the ID Token and apply RP tenant-specific policies (e.g., access control, consent requirements, authentication methods). When present, the OP MUST echo this value back in the <code>aud_tenant</code> claim. See Section "Authentication Request Parameters" for details.<a href="#appendix-A.4-3.1.1" class="pilcrow">¶</a></p>
+</li>
+          <li class="normal" id="appendix-A.4-3.2">
+            <p id="appendix-A.4-3.2.1"><strong><code>state</code> parameter or session context</strong>: RPs may include tenant identification information in the opaque <code>state</code> parameter of the OpenID Connect Authentication Request, or maintain tenant context via cookies or other session mechanisms. When the RP uses only this mechanism, the OP does not have access to the tenant identifier and MUST omit the <code>aud_tenant</code> claim from the ID Token. The OP cannot apply RP tenant-specific policies, and the RP MUST use implementation-specific mechanisms (such as parsing the <code>state</code> parameter or session context) to determine the tenant for routing the authentication response. This pattern is commonly used in practice.<a href="#appendix-A.4-3.2.1" class="pilcrow">¶</a></p>
+</li>
+          <li class="normal" id="appendix-A.4-3.3">
+            <p id="appendix-A.4-3.3.1"><strong><code>redirect_uri</code></strong>: RPs may register a <code>redirect_uri</code> per tenant and include the specific tenant redirect_uri in the OpenID Connect Authentication Request. The OP MUST treat the <code>redirect_uri</code> as opaque and MUST NOT attempt to identify a tenant from a specific URL endpoint or pattern. This mechanism only enables RP-side tenant routing; the OP cannot apply RP tenant-specific policies using this approach.<a href="#appendix-A.4-3.3.1" class="pilcrow">¶</a></p>
+</li>
+        </ul>
+<p id="appendix-A.4-4">If the RP does not provide a <code>client_tenant</code> parameter and the OP cannot determine the RP tenant identifier from other mechanisms (such as <code>state</code> or <code>redirect_uri</code>), the OP MAY attempt to resolve the RP tenant using other available information (e.g., <code>domain_hint</code>, <code>login_hint</code>) or MAY select a default tenant for the client, or MAY prompt the end-user to select a valid tenant for the client. If the OP successfully determines the RP tenant identifier through any of these means, it SHOULD include it in the <code>aud_tenant</code> claim of the ID Token.<a href="#appendix-A.4-4" class="pilcrow">¶</a></p>
+<p id="appendix-A.4-5">The following diagram illustrates RP tenant communication flow:<a href="#appendix-A.4-5" class="pilcrow">¶</a></p>
+<div class="alignLeft art-text artwork" id="appendix-A.4-6">
+<pre>┌─────────────────────┐                    ┌─────────────────────┐
+│         RP          │                    │         OP          │
+│                     │                    │                     │
+│ 1. RP identifies    │                    │                     │
+│    its tenant       │                    │                     │
+│    context          │                    │                     │
+│    (e.g., from URL, │                    │                     │
+│    session, config) │                    │                     │
+│                     │                    │                     │
+│ 2. Authentication   │                    │                     │
+│    Request          │                    │                     │
+│    └─ client_tenant=│                    │                     │
+│       acme-corp-    │                    │                     │
+│       tenant-id     │                    │                     │
+│         │───────────────────────────────&gt;│                     │
+│         │                                │                     │
+│         │                                │ 3. OP validates     │
+│         │                                │    client_tenant    │
+│         │                                │    (if tenants      │
+│         │                                │    registered)      │
+│         │                                │                     │
+│         │                                │ 4. User auth        │
+│         │                                │                     │
+│         │ 5. ID Token                    │                     │
+│         │    └─ aud_tenant:              │                     │
+│         │        "acme-corp-tenant-id"   │                     │
+│         │&lt;───────────────────────────────│                     │
+│         │                                │                     │
+│ 6. RP validates     │                    │                     │
+│    aud_tenant claim │                    │                     │
+│    matches          │                    │                     │
+│    client_tenant    │                    │                     │
+│    sent and routes  │                    │                     │
+│    to correct       │                    │                     │
+│    tenant           │                    │                     │
+└─────────────────────┘                    └─────────────────────┘
+</pre><a href="#appendix-A.4-6" class="pilcrow">¶</a>
+</div>
+</section>
+</div>
+</section>
+</div>
+<div id="acknowledgements">
+<section id="appendix-B">
+      <h2 id="name-acknowledgements">
+<a href="#appendix-B" class="section-number selfRef">Appendix B. </a><a href="#name-acknowledgements" class="section-name selfRef">Acknowledgements</a>
+      </h2>
+<p id="appendix-B-1"><em>To be updated.</em><a href="#appendix-B-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="notices">
+<section id="appendix-C">
+      <h2 id="name-notices">
+<a href="#appendix-C" class="section-number selfRef">Appendix C. </a><a href="#name-notices" class="section-name selfRef">Notices</a>
+      </h2>
+<p id="appendix-C-1">Copyright (c) 2025 The OpenID Foundation.<a href="#appendix-C-1" class="pilcrow">¶</a></p>
+<p id="appendix-C-2">The OpenID Foundation (OIDF) grants to any Contributor, developer,
+implementer, or other interested party a non-exclusive, royalty free,
+worldwide copyright license to reproduce, prepare derivative works from,
+distribute, perform and display, this Implementers Draft, Final
+Specification, or Final Specification Incorporating Errata Corrections
+solely for the purposes of (i) developing specifications,
+and (ii) implementing Implementers Drafts, Final Specifications,
+and Final Specification Incorporating Errata Corrections based
+on such documents, provided that attribution be made to the OIDF as the
+source of the material, but that such attribution does not indicate an
+endorsement by the OIDF.<a href="#appendix-C-2" class="pilcrow">¶</a></p>
+<p id="appendix-C-3">The technology described in this specification was made available
+from contributions from various sources, including members of the OpenID
+Foundation and others. Although the OpenID Foundation has taken steps to
+help ensure that the technology is available for distribution, it takes
+no position regarding the validity or scope of any intellectual property
+or other rights that might be claimed to pertain to the implementation
+or use of the technology described in this specification or the extent
+to which any license under such rights might or might not be available;
+neither does it represent that it has made any independent effort to
+identify any such rights. The OpenID Foundation and the contributors to
+this specification make no (and hereby expressly disclaim any)
+warranties (express, implied, or otherwise), including implied
+warranties of merchantability, non-infringement, fitness for a
+particular purpose, or title, related to this specification, and the
+entire risk as to implementing this specification is assumed by the
+implementer. The OpenID Intellectual Property Rights policy
+(found at openid.net) requires
+contributors to offer a patent promise not to assert certain patent
+claims against other contributors and against implementers.
+OpenID invites any interested party to bring to its attention any
+copyrights, patents, patent applications, or other proprietary rights
+that may cover technology that may be required to practice this
+specification.<a href="#appendix-C-3" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="document-history">
+<section id="appendix-D">
+      <h2 id="name-document-history">
+<a href="#appendix-D" class="section-number selfRef">Appendix D. </a><a href="#name-document-history" class="section-name selfRef">Document History</a>
+      </h2>
+<p id="appendix-D-1">[[ To be removed from the final specification ]]<a href="#appendix-D-1" class="pilcrow">¶</a></p>
+<p id="appendix-D-2">-00<a href="#appendix-D-2" class="pilcrow">¶</a></p>
+<p id="appendix-D-3">initial draft<a href="#appendix-D-3" class="pilcrow">¶</a></p>
+<p id="appendix-D-4">-01<a href="#appendix-D-4" class="pilcrow">¶</a></p>
+<ul class="compact">
+<li class="compact" id="appendix-D-5.1">added <code>aud_sub</code> claim<a href="#appendix-D-5.1" class="pilcrow">¶</a>
+</li>
+      </ul>
+<p id="appendix-D-6">-02<a href="#appendix-D-6" class="pilcrow">¶</a></p>
+<ul class="compact">
+<li class="compact" id="appendix-D-7.1">added <code>aud_tenant</code> claim<a href="#appendix-D-7.1" class="pilcrow">¶</a>
+</li>
+        <li class="compact" id="appendix-D-7.2">added <code>client_tenant</code> authentication request parameter<a href="#appendix-D-7.2" class="pilcrow">¶</a>
+</li>
+        <li class="compact" id="appendix-D-7.3">added <code>tenants</code> client registration parameter<a href="#appendix-D-7.3" class="pilcrow">¶</a>
+</li>
+        <li class="compact" id="appendix-D-7.4">added <code>client_tenant</code> to Login from a Third Party parameters<a href="#appendix-D-7.4" class="pilcrow">¶</a>
+</li>
+        <li class="compact" id="appendix-D-7.5">added Tenancy Models appendix to describe OP and RP tenancy models and relationships<a href="#appendix-D-7.5" class="pilcrow">¶</a>
+</li>
+        <li class="compact" id="appendix-D-7.6">added Security Considerations<a href="#appendix-D-7.6" class="pilcrow">¶</a>
+</li>
+      </ul>
+</section>
+</div>
+<div id="authors-addresses">
+<section id="appendix-E">
+      <h2 id="name-authors-addresses">
+<a href="#name-authors-addresses" class="section-name selfRef">Authors' Addresses</a>
+      </h2>
+<address class="vcard">
+        <div dir="auto" class="left"><span class="fn nameRole">Dick Hardt</span></div>
+<div dir="auto" class="left"><span class="org">Hellō</span></div>
+<div class="email">
+<span>Email:</span>
+<a href="mailto:dick.hardt@gmail.com" class="email">dick.hardt@gmail.com</a>
+</div>
+</address>
+<address class="vcard">
+        <div dir="auto" class="left"><span class="fn nameRole">Karl McGuinness</span></div>
+<div dir="auto" class="left"><span class="org">Independent</span></div>
+<div class="email">
+<span>Email:</span>
+<a href="mailto:me@karlmcguinness.com" class="email">me@karlmcguinness.com</a>
+</div>
+</address>
+</section>
+</div>
+<script>const toc = document.getElementById("toc");
+toc.querySelector("h2").addEventListener("click", e => {
+  toc.classList.toggle("active");
+});
+toc.querySelector("nav").addEventListener("click", e => {
+  toc.classList.remove("active");
+});
+</script>
+</body>
+</html>

--- a/openid-connect-enterprise-extensions-1_0.html
+++ b/openid-connect-enterprise-extensions-1_0.html
@@ -2405,17 +2405,19 @@ specification.<a href="#appendix-C-3" class="pilcrow">¶</a></p>
       </ul>
 <p id="appendix-D-6">-02<a href="#appendix-D-6" class="pilcrow">¶</a></p>
 <ul class="compact">
-<li class="compact" id="appendix-D-7.1">added <code>aud_tenant</code> claim<a href="#appendix-D-7.1" class="pilcrow">¶</a>
+<li class="compact" id="appendix-D-7.1">updated <code>tenant</code> claim rules<a href="#appendix-D-7.1" class="pilcrow">¶</a>
 </li>
-        <li class="compact" id="appendix-D-7.2">added <code>client_tenant</code> authentication request parameter<a href="#appendix-D-7.2" class="pilcrow">¶</a>
+        <li class="compact" id="appendix-D-7.2">added <code>aud_tenant</code> claim<a href="#appendix-D-7.2" class="pilcrow">¶</a>
 </li>
-        <li class="compact" id="appendix-D-7.3">added <code>tenants</code> client registration parameter<a href="#appendix-D-7.3" class="pilcrow">¶</a>
+        <li class="compact" id="appendix-D-7.3">added <code>client_tenant</code> authentication request parameter<a href="#appendix-D-7.3" class="pilcrow">¶</a>
 </li>
-        <li class="compact" id="appendix-D-7.4">added <code>client_tenant</code> to Login from a Third Party parameters<a href="#appendix-D-7.4" class="pilcrow">¶</a>
+        <li class="compact" id="appendix-D-7.4">added <code>tenants</code> client registration parameter<a href="#appendix-D-7.4" class="pilcrow">¶</a>
 </li>
-        <li class="compact" id="appendix-D-7.5">added Tenancy Models appendix to describe OP and RP tenancy models and relationships<a href="#appendix-D-7.5" class="pilcrow">¶</a>
+        <li class="compact" id="appendix-D-7.5">added <code>client_tenant</code> to Login from a Third Party parameters<a href="#appendix-D-7.5" class="pilcrow">¶</a>
 </li>
-        <li class="compact" id="appendix-D-7.6">added Security Considerations<a href="#appendix-D-7.6" class="pilcrow">¶</a>
+        <li class="compact" id="appendix-D-7.6">added Tenancy Models appendix to describe OP and RP tenancy models and relationships<a href="#appendix-D-7.6" class="pilcrow">¶</a>
+</li>
+        <li class="compact" id="appendix-D-7.7">added Security Considerations<a href="#appendix-D-7.7" class="pilcrow">¶</a>
 </li>
       </ul>
 </section>

--- a/openid-connect-enterprise-extensions-1_0.md
+++ b/openid-connect-enterprise-extensions-1_0.md
@@ -128,7 +128,7 @@ When the `aud_tenant` claim is present, the `aud_sub` claim represents the accou
 
 ## aud_tenant
 
-The `aud_tenant` claim is a JSON string that represents an RP tenant identifier. This claim is OPTIONAL and is only included when the RP is multi-tenant and the OP knows the RP tenant identifier (see Appendix A for how the RP communicates its tenant identifier to the OP).
+The `aud_tenant` claim is a JSON string that represents an RP tenant identifier. This claim is OPTIONAL and is only included when the RP is multi-tenant and the OP knows the RP tenant identifier (see [Appendix A](#enterprise-tenancy-models) for how the RP communicates its tenant identifier to the OP).
 
 When the RP provides the `client_tenant` authentication request parameter, the `aud_tenant` claim value MUST be the same value that the RP provided in that parameter. When the OP determines the RP tenant identifier through other means (e.g., `domain_hint`, `login_hint`, default tenant selection, or end-user selection), the `aud_tenant` claim value MUST be a valid RP tenant identifier for the client. The value is opaque to the OP (the OP does not need to understand its semantic meaning). The value MUST be a stable identifier that is unique within the context of the `client_id` used in the authentication request, ensuring that when multiple RP tenants share the same `client_id`, each tenant can be uniquely identified.
 
@@ -148,7 +148,7 @@ The `domain_hint` parameter provides a hint for the OP to determine which OP ten
 
 The `tenant` parameter is the explicit OP tenant identifier value that corresponds to the `tenant` claim the RP would like included in the ID Token. This parameter takes precedence over `domain_hint` when both are present. 
 
-The `tenant` parameter value MUST be one of the allowed values for the OP model as specified in the table in Section "tenant":
+The `tenant` parameter value MUST be one of the allowed values for the OP model as specified in the table in [Section "tenant"](#tenant):
 
 - The value `personal` to indicate the RP would like the user to use a personal account (valid for all OP models)
 - The value `organization` to indicate the RP would like the user to use an organizational account (valid for single-tenant OPs and multi-tenant OPs using tenant-specific issuers only)
@@ -158,7 +158,7 @@ If the `tenant` parameter value does not match any OP tenant, the OP SHOULD retu
 
 ## client_tenant
 
-The `client_tenant` parameter is an OPTIONAL parameter that the RP includes to communicate its RP tenant identifier to the OP. This parameter is used when the RP is multi-tenant and uses a shared `client_id` across multiple RP tenants (see Appendix A for details on multi-tenant RP models).
+The `client_tenant` parameter is an OPTIONAL parameter that the RP includes to communicate its RP tenant identifier to the OP. This parameter is used when the RP is multi-tenant and uses a shared `client_id` across multiple RP tenants (see [Appendix A](#enterprise-tenancy-models) for details on multi-tenant RP models).
 
 The client MAY register allowed tenants using the `tenants` client registration parameter. When the `client_tenant` authentication request parameter is provided, the OP SHOULD validate that the `client_tenant` value corresponds to a valid RP tenant identifier that was registered for this client.
 
@@ -232,11 +232,11 @@ The `client_tenant` value to be included in the Authentication Request.
 
 ### Tenant Isolation
 
-OPs MUST ensure strict isolation between tenants. An authenticated user from one OP tenant MUST NOT be able to obtain tokens containing a different tenant's identifier. The OP MUST validate that the `tenant` claim (see Section "ID Token Claims") in issued ID Tokens accurately reflects the tenant context in which the user authenticated.
+OPs MUST ensure strict isolation between tenants. An authenticated user from one OP tenant MUST NOT be able to obtain tokens containing a different tenant's identifier. The OP MUST validate that the `tenant` claim (see [Section "ID Token Claims"](#id-token-claims)) in issued ID Tokens accurately reflects the tenant context in which the user authenticated.
 
 ### Client Tenant Validation
 
-When the OP receives a `client_tenant` authentication request parameter (see Section "Authentication Request Parameters"), the OP SHOULD validate that the value corresponds to a registered RP tenant identifier for the given `client_id`. If the OP has registered the `tenants` client registration parameter (see Section "Client Registration Parameters") for the client, the OP SHOULD reject requests where `client_tenant` is not in the registered list.
+When the OP receives a `client_tenant` authentication request parameter (see [Section "Authentication Request Parameters"](#authentication-request-parameters)), the OP SHOULD validate that the value corresponds to a registered RP tenant identifier for the given `client_id`. If the OP has registered the `tenants` client registration parameter (see [Section "Client Registration Parameters"](#client-registration-parameters)) for the client, the OP SHOULD reject requests where `client_tenant` is not in the registered list.
 
 Failure to validate the `client_tenant` parameter could allow an attacker to request tokens for arbitrary RP tenants, potentially bypassing RP tenant-specific policies configured at the OP.
 
@@ -244,9 +244,9 @@ Failure to validate the `client_tenant` parameter could allow an attacker to req
 
 Multi-tenant OPs MUST ensure that subject identifiers are unambiguous across tenants to prevent account confusion where an RP incorrectly links accounts from different OP tenants.
 
-For multi-tenant OPs using a single issuer (see Appendix A), the OP MUST ensure that subject identifiers are unambiguous across tenants. If the same `sub` value could exist in multiple OP tenants, the OP MUST include the `tenant` claim (see Section "ID Token Claims") in the ID Token to enable RPs to correctly identify the account. The combination of `iss` + `tenant` + `sub` (for public subject identifiers) or `iss` + `tenant` + `client_id` + `sub` (for pairwise subject identifiers) MUST be unique across all tenants (see Appendix A for detailed requirements).
+For multi-tenant OPs using a single issuer (see [Appendix A](#enterprise-tenancy-models)), the OP MUST ensure that subject identifiers are unambiguous across tenants. If the same `sub` value could exist in multiple OP tenants, the OP MUST include the `tenant` claim (see [Section "ID Token Claims"](#id-token-claims)) in the ID Token to enable RPs to correctly identify the account. The combination of `iss` + `tenant` + `sub` (for public subject identifiers) or `iss` + `tenant` + `client_id` + `sub` (for pairwise subject identifiers) MUST be unique across all tenants (see [Appendix A](#enterprise-tenancy-models) for detailed requirements).
 
-For multi-tenant OPs using tenant-specific issuer identifiers (see Appendix A), the OP MUST ensure that the combination of `iss` + `sub` (for public subject identifiers) or `iss` + `client_id` + `sub` (for pairwise subject identifiers) is unique across all tenants. Since each tenant has a different issuer identifier, the OIDC Core requirement that `sub` is unique within `iss` already ensures tenant isolation. However, the OP MUST ensure uniqueness across all tenants, regardless of whether a client is shared across tenants or unique per tenant (see Appendix A for detailed requirements).
+For multi-tenant OPs using tenant-specific issuer identifiers (see [Appendix A](#enterprise-tenancy-models)), the OP MUST ensure that the combination of `iss` + `sub` (for public subject identifiers) or `iss` + `client_id` + `sub` (for pairwise subject identifiers) is unique across all tenants. Since each tenant has a different issuer identifier, the OIDC Core requirement that `sub` is unique within `iss` already ensures tenant isolation. However, the OP MUST ensure uniqueness across all tenants, regardless of whether a client is shared across tenants or unique per tenant (see [Appendix A](#enterprise-tenancy-models) for detailed requirements).
 
 ### Token Injection Prevention
 
@@ -256,7 +256,7 @@ OPs SHOULD implement measures to prevent token injection attacks where an attack
 
 ### Tenant Claim Validation
 
-When an RP expects to receive the `tenant` claim (see Section "ID Token Claims") (e.g., when authenticating to a multi-tenant OP using a single issuer, as described in Appendix A), the RP MUST validate that the `tenant` claim is present in the ID Token. If the RP has prior knowledge of the expected tenant (e.g., from a previous authentication or configuration), the RP SHOULD validate that the received `tenant` claim matches the expected value.
+When an RP expects to receive the `tenant` claim (see [Section "ID Token Claims"](#id-token-claims)) (e.g., when authenticating to a multi-tenant OP using a single issuer, as described in [Appendix A](#enterprise-tenancy-models)), the RP MUST validate that the `tenant` claim is present in the ID Token. If the RP has prior knowledge of the expected tenant (e.g., from a previous authentication or configuration), the RP SHOULD validate that the received `tenant` claim matches the expected value.
 
 Failure to validate the `tenant` claim could result in:
 - Account confusion where users from different OP tenants are incorrectly linked
@@ -264,16 +264,16 @@ Failure to validate the `tenant` claim could result in:
 
 ### aud_tenant Claim Validation
 
-When an RP sends the `client_tenant` authentication request parameter (see Section "Authentication Request Parameters"), the RP MUST validate that the returned `aud_tenant` claim (see Section "ID Token Claims") matches the value sent in the request. If the `aud_tenant` claim is missing or contains a different value, the RP MUST reject the ID Token.
+When an RP sends the `client_tenant` authentication request parameter (see [Section "Authentication Request Parameters"](#authentication-request-parameters)), the RP MUST validate that the returned `aud_tenant` claim (see [Section "ID Token Claims"](#id-token-claims)) matches the value sent in the request. If the `aud_tenant` claim is missing or contains a different value, the RP MUST reject the ID Token.
 
-This validation prevents an attacker from obtaining a token intended for one RP tenant and using it to authenticate to a different RP tenant. See Appendix A for details on how the `client_tenant` parameter relates to the `aud_tenant` claim.
+This validation prevents an attacker from obtaining a token intended for one RP tenant and using it to authenticate to a different RP tenant. See [Appendix A](#enterprise-tenancy-models) for details on how the `client_tenant` parameter relates to the `aud_tenant` claim.
 
 ### Account Identifier Uniqueness
 
 RPs MUST use the complete set of identifying claims when linking accounts:
-- For multi-tenant OPs using a single issuer (see Appendix A): `iss` + `tenant` (see Section "ID Token Claims") + `sub`
-- For multi-tenant OPs using tenant-specific issuers (see Appendix A): `iss` + `sub`
-- For multi-tenant RPs with shared `client_id` (see Appendix A): `aud` + `aud_tenant` (see Section "ID Token Claims") + `aud_sub` (see Section "ID Token Claims") (when present)
+- For multi-tenant OPs using a single issuer (see [Appendix A](#enterprise-tenancy-models)): `iss` + `tenant` (see [Section "ID Token Claims"](#id-token-claims)) + `sub`
+- For multi-tenant OPs using tenant-specific issuers (see [Appendix A](#enterprise-tenancy-models)): `iss` + `sub`
+- For multi-tenant RPs with shared `client_id` (see [Appendix A](#enterprise-tenancy-models)): `aud` + `aud_tenant` (see [Section "ID Token Claims"](#id-token-claims)) + `aud_sub` (see [Section "ID Token Claims"](#id-token-claims)) (when present)
 
 Using only a subset of these claims (e.g., only `sub`) could result in incorrectly linking accounts from different tenants.
 
@@ -371,7 +371,7 @@ An OP can have a single-tenant issuer or a multi-tenant issuer:
   ```
 
 - **Multi-tenant OP**: The OP has multiple tenants. Multi-tenant OPs may use a single issuer identifier for all tenants, or tenant-specific issuer identifiers:
-  - **Single issuer for all tenants**: The OP uses one issuer identifier for all tenants, and the `tenant` claim (see Section "ID Token Claims") distinguishes between tenants.
+  - **Single issuer for all tenants**: The OP uses one issuer identifier for all tenants, and the `tenant` claim (see [Section "ID Token Claims"](#id-token-claims)) distinguishes between tenants.
 
     - **Issuer Configuration**: All tenants share the same issuer identifier (`iss`), OP metadata endpoint, and signing keys.
 
@@ -432,10 +432,10 @@ The following table summarizes OP tenancy models:
 | Model | Issuer Configuration | Uniqueness Requirement | Tenant Identification |
 |-------|---------------------|------------------------|---------------------|
 | Single-tenant OP | Single `iss`, single metadata endpoint, single signing keys | `public`: `sub` unique within `iss`<br/>`pairwise`: `iss` + `client_id` + `sub` unique | Not applicable |
-| Multi-tenant OP (single issuer) | Single `iss` shared across tenants, single metadata endpoint, single signing keys | `public`: `iss` + `tenant` + `sub` unique<br/>`pairwise`: `iss` + `tenant` + `client_id` + `sub` unique | `tenant` claim in ID Token (see Section "ID Token Claims") |
+| Multi-tenant OP (single issuer) | Single `iss` shared across tenants, single metadata endpoint, single signing keys | `public`: `iss` + `tenant` + `sub` unique<br/>`pairwise`: `iss` + `tenant` + `client_id` + `sub` unique | `tenant` claim in ID Token (see [Section "ID Token Claims"](#id-token-claims)) |
 | Multi-tenant OP (tenant-specific issuers) | Each tenant has own `iss`, metadata endpoint, and signing keys | `public`: `iss` + `sub` unique (per tenant)<br/>`pairwise`: `iss` + `client_id` + `sub` unique (per tenant) | `iss` value identifies tenant |
 
-- **Discovery**: If an OP publishes support for the `tenant` claim in the `claims_supported` metadata parameter (see [OpenID Connect Discovery 1.0]), then RPs SHOULD assume that the issuer is a multi-tenant OP using a single issuer identifier and SHOULD expect the `tenant` claim to be present in ID Tokens. The `tenant` claim value MUST be one of the allowed values for the corresponding OP model as specified in the table in Section "tenant".
+- **Discovery**: If an OP publishes support for the `tenant` claim in the `claims_supported` metadata parameter (see [OpenID Connect Discovery 1.0]), then RPs SHOULD assume that the issuer is a multi-tenant OP using a single issuer identifier and SHOULD expect the `tenant` claim to be present in ID Tokens. The `tenant` claim value MUST be one of the allowed values for the corresponding OP model as specified in the table in [Section "tenant"](#tenant).
 
 ## OP Tenant Communication
 
@@ -443,9 +443,9 @@ When the OP uses tenant-specific issuer identifiers, the RP authenticates to the
 
 The following applies only to multi-tenant OPs that use a single issuer for all tenants. For such OPs, the RP MAY specify which OP tenant it wants the user to authenticate to using one of the following mechanisms:
 
-- **`tenant` parameter**: The RP includes the `tenant` parameter in the authentication request with the OP tenant identifier value (e.g., `tenant=acme-corp`). When the OP receives this parameter, it SHOULD include the `tenant` claim in the ID Token with the same value. This is RECOMMENDED for RPs that know which `tenant` to make an authentication request to. See Section "Authentication Request Parameters" for details.
+- **`tenant` parameter**: The RP includes the `tenant` parameter in the authentication request with the OP tenant identifier value (e.g., `tenant=acme-corp`). When the OP receives this parameter, it SHOULD include the `tenant` claim in the ID Token with the same value. This is RECOMMENDED for RPs that know which `tenant` to make an authentication request to. See [Section "Authentication Request Parameters"](#authentication-request-parameters) for details.
 
-- **`domain_hint` parameter**: The RP includes the `domain_hint` parameter with a domain name or email domain (e.g., `example.com`) that helps the OP identify the appropriate tenant. This is a user experience hint and is not guaranteed to uniquely identify a tenant. When both `tenant` and `domain_hint` are present, the `tenant` parameter takes precedence. If the OP cannot uniquely identify the tenant from `domain_hint` alone, the OP's tenant selection behavior is implementation-dependent. See Section "Authentication Request Parameters" for details.
+- **`domain_hint` parameter**: The RP includes the `domain_hint` parameter with a domain name or email domain (e.g., `example.com`) that helps the OP identify the appropriate tenant. This is a user experience hint and is not guaranteed to uniquely identify a tenant. When both `tenant` and `domain_hint` are present, the `tenant` parameter takes precedence. If the OP cannot uniquely identify the tenant from `domain_hint` alone, the OP's tenant selection behavior is implementation-dependent. See [Section "Authentication Request Parameters"](#authentication-request-parameters) for details.
 
 When the OP tenant is not specified by the RP (neither `tenant` nor `domain_hint` is provided, or `domain_hint` does not uniquely identify a tenant), the OP MAY:
 - Provide a selector to allow the end-user to pick the tenant during authentication
@@ -538,7 +538,7 @@ An RP can be single-tenant or multi-tenant:
       ```
 
   - **Shared Client for all Tenants**: Multiple RP tenants share a single `client_id` registered with the OP.
-    - **Registration**: All RP tenants share a single `client_id` registered with the OP. The RP MAY register the `tenants` client registration parameter (see Section "Client Registration Parameters") as a JSON array of strings containing the RP tenant identifiers.
+    - **Registration**: All RP tenants share a single `client_id` registered with the OP. The RP MAY register the `tenants` client registration parameter (see [Section "Client Registration Parameters"](#client-registration-parameters)) as a JSON array of strings containing the RP tenant identifiers.
     - **Account Identifier Uniqueness**: When both `aud_tenant` and `aud_sub` are present, their combination MUST be unique for a given `aud` (client identifier) within the RP. This ensures that account identifiers are unambiguous within the context of the RP, even when the same `aud_sub` value might exist in different RP tenants.
 
     For example:
@@ -569,17 +569,17 @@ The following table summarizes RP tenancy models:
 |-------|--------------|------------------------------|----------------------|
 | Single-tenant RP | Single `client_id` registered with OP issuer | `aud_sub` unique within `client_id` | Not applicable |
 | Multi-tenant RP (unique client per tenant) | Each tenant has own `client_id` registered with OP issuer | `aud_sub` unique within `client_id` | `aud` identifies tenant |
-| Multi-tenant RP (shared client) | Single `client_id` shared across tenants, `tenants` parameter MAY be registered | `aud_tenant` + `aud_sub` unique within `aud` | `aud` + `aud_tenant` claim in ID Token (see Section "ID Token Claims") |
+| Multi-tenant RP (shared client) | Single `client_id` shared across tenants, `tenants` parameter MAY be registered | `aud_tenant` + `aud_sub` unique within `aud` | `aud` + `aud_tenant` claim in ID Token (see [Section "ID Token Claims"](#id-token-claims)) |
 
 - **Discovery**: If an RP supports multiple tenants and registers the `tenants` client registration parameter for the client, then OPs SHOULD assume the RP is multi-tenant.
 
 ## RP Tenant Communication
 
-When an RP is multi-tenant and uses a shared `client_id`, the RP MAY communicate its tenant identifier to the OP, but is not required to do so. If the OP knows the RP tenant identifier, it SHOULD include it in the `aud_tenant` claim of the ID Token (see Section "ID Token Claims").
+When an RP is multi-tenant and uses a shared `client_id`, the RP MAY communicate its tenant identifier to the OP, but is not required to do so. If the OP knows the RP tenant identifier, it SHOULD include it in the `aud_tenant` claim of the ID Token (see [Section "ID Token Claims"](#id-token-claims)).
 
 The RP can communicate its tenant identifier using one of the following mechanisms:
 
-- **`client_tenant` authentication request parameter** (RECOMMENDED): The RP includes the `client_tenant` parameter in the authentication request with its tenant identifier value. This is explicit and unambiguous, allowing the OP to include the `aud_tenant` claim in the ID Token and apply RP tenant-specific policies (e.g., access control, consent requirements, authentication methods). When present, the OP MUST echo this value back in the `aud_tenant` claim. See Section "Authentication Request Parameters" for details.
+- **`client_tenant` authentication request parameter** (RECOMMENDED): The RP includes the `client_tenant` parameter in the authentication request with its tenant identifier value. This is explicit and unambiguous, allowing the OP to include the `aud_tenant` claim in the ID Token and apply RP tenant-specific policies (e.g., access control, consent requirements, authentication methods). When present, the OP MUST echo this value back in the `aud_tenant` claim. See [Section "Authentication Request Parameters"](#authentication-request-parameters) for details.
 
 - **`state` parameter or session context**: RPs may include tenant identification information in the opaque `state` parameter of the OpenID Connect Authentication Request, or maintain tenant context via cookies or other session mechanisms. When the RP uses only this mechanism, the OP does not have access to the tenant identifier and MUST omit the `aud_tenant` claim from the ID Token. The OP cannot apply RP tenant-specific policies, and the RP MUST use implementation-specific mechanisms (such as parsing the `state` parameter or session context) to determine the tenant for routing the authentication response. This pattern is commonly used in practice.
 

--- a/openid-connect-enterprise-extensions-1_0.md
+++ b/openid-connect-enterprise-extensions-1_0.md
@@ -88,28 +88,35 @@ The `session_expiry` claim is a JSON integer that represents the Unix timestamp 
 
 The `tenant` claim is a JSON string that represents an OP tenant identifier. This claim is OPTIONAL and MAY be included in ID Tokens.
 
-- **Single-tenant OPs**: Single-tenant OPs SHOULD omit the `tenant` claim.
+The following well-known values are defined for the `tenant` claim:
 
-- **Multi-tenant OPs using a single issuer**: Multi-tenant OPs using a single issuer identifier SHOULD include the `tenant` claim to identify the OP tenant. The value MUST be a stable, opaque to the RP, OP unique identifier or a well known special value described below.
+- `personal`: Indicates that accounts are managed by individuals rather than by a specific organizational tenant.
+- `organization`: Indicates that accounts are managed by an organization.
+
+- **Single-tenant OPs**: Single-tenant OPs MAY include the `tenant` claim. If included, the value MUST be `personal` or `organization`.
+
+- **Multi-tenant OPs using a single issuer**: Multi-tenant OPs using a single issuer identifier SHOULD include the `tenant` claim to identify the OP tenant. The value MUST be `personal` or a stable, opaque to the RP, OP unique tenant identifier.
 
   - The combination of `iss`, `tenant`, and `sub` MUST be unique across all OP tenants.
   - If the OP uses `pairwise` subject identifiers, the same user MAY have the same `sub` for the same `client_id` regardless of OP tenant. The `tenant` claim SHOULD be included in the uniqueness requirement (`iss` + `tenant` + `sub`) to disambiguate subjects across tenants.
   - If the OP uses `public` subject identifiers, the `sub` value MUST be the same across all RPs/clients and all OP tenants. The `tenant` claim MUST be included in the uniqueness requirement (`iss` + `tenant` + `sub`) to disambiguate subjects across tenants.
 
-- **Multi-tenant OPs using tenant-specific issuer identifiers**: Multi-tenant OPs using tenant-specific issuer identifiers SHOULD omit the `tenant` claim since the issuer identifier itself identifies the tenant.
+- **Multi-tenant OPs using tenant-specific issuer identifiers**: Multi-tenant OPs using tenant-specific issuer identifiers SHOULD omit the `tenant` claim since the issuer identifier itself identifies the tenant. If the `tenant` claim is included, the value MUST be `personal` or `organization`.
 
   - Each tenant issuer identifier MUST be a valid URL per [OpenID Connect Core 1.0] Section 2.
   - The combination of `iss` and `sub` MUST be unique per tenant.
   - If the OP uses `pairwise` subject identifiers, the `sub` value MUST differ across `client_id` values within each tenant. The combination of `iss` + `client_id` + `sub` MUST be unique across all tenants.
   - If the OP uses `public` subject identifiers, the `sub` value MUST be the same across all RPs/clients within each tenant. The `sub` value MAY be the same across tenants, but the combination of `iss` + `sub` MUST be unique across all tenants.
 
-- **Special values**: The `tenant` claim MAY have the well-known value `personal` or `organization` instead of a unique identifier.
-  - `personal`: Indicates that accounts are managed by individuals rather than by a specific organizational tenant.
-  - `organization`: Indicates that accounts are managed by an organization.
+- **Discovery**: If an OP publishes support for the `tenant` claim in the `claims_supported` metadata parameter (see [OpenID Connect Discovery 1.0]), then RPs SHOULD assume that the issuer is a multi-tenant OP using a single issuer identifier and SHOULD expect the `tenant` claim to be present in ID Tokens. The `tenant` claim value MUST be one of the allowed values for the corresponding OP model as specified in the table below.
 
-For multi-tenant OPs using tenant-specific issuer identifiers, if the `tenant` claim is present and does not match the tenant identified by the `iss` value, the RP SHOULD treat this as an error condition.
+The following table summarizes the `tenant` claim rules by OP model:
 
-- **Discovery**: If an OP publishes support for the `tenant` claim in the `claims_supported` metadata parameter (see [OpenID Connect Discovery 1.0]), then RPs SHOULD assume that the issuer supports multiple tenants and SHOULD expect the `tenant` claim to be present in ID Tokens.
+| OP Model | Allowed Values |
+|----------|----------------|
+| Single-tenant | `personal` or `organization` |
+| Multi-tenant (single issuer) | `personal` or unique tenant identifier |
+| Multi-tenant (tenant-specific issuers) | `personal` or `organization` |
 
 ## aud_sub
 
@@ -141,10 +148,11 @@ The `domain_hint` parameter provides a hint for the OP to determine which OP ten
 
 The `tenant` parameter is the explicit OP tenant identifier value that corresponds to the `tenant` claim the RP would like included in the ID Token. This parameter takes precedence over `domain_hint` when both are present. 
 
-The `tenant` parameter value MUST match one of the following:
-- The value `personal` to indicate the RP would like the user to use an account managed by the user (personal account)
-- The value `organization` to indicate the RP would like the user to use an account managed by an organization (organizational account)
-- A stable, opaque OP tenant identifier value for multi-tenant OPs
+The `tenant` parameter value MUST be one of the allowed values for the OP model as specified in the table in Section "tenant":
+
+- The value `personal` to indicate the RP would like the user to use a personal account (valid for all OP models)
+- The value `organization` to indicate the RP would like the user to use an organizational account (valid for single-tenant OPs and multi-tenant OPs using tenant-specific issuers only)
+- A stable, opaque OP tenant identifier (valid for multi-tenant OPs using a single issuer only)
 
 If the `tenant` parameter value does not match any OP tenant, the OP SHOULD return an `invalid_request` error or proceed with the authentication using the OP's default tenant selection logic. The specific behavior is implementation-dependent.
 
@@ -427,7 +435,7 @@ The following table summarizes OP tenancy models:
 | Multi-tenant OP (single issuer) | Single `iss` shared across tenants, single metadata endpoint, single signing keys | `public`: `iss` + `tenant` + `sub` unique<br/>`pairwise`: `iss` + `tenant` + `client_id` + `sub` unique | `tenant` claim in ID Token (see Section "ID Token Claims") |
 | Multi-tenant OP (tenant-specific issuers) | Each tenant has own `iss`, metadata endpoint, and signing keys | `public`: `iss` + `sub` unique (per tenant)<br/>`pairwise`: `iss` + `client_id` + `sub` unique (per tenant) | `iss` value identifies tenant |
 
-- **Discovery**: If an OP publishes support for the `tenant` claim in the `claims_supported` metadata parameter (see [OpenID Connect Discovery 1.0]), then RPs SHOULD assume that the issuer supports multiple tenants and SHOULD expect the `tenant` claim to be present in ID Tokens.
+- **Discovery**: If an OP publishes support for the `tenant` claim in the `claims_supported` metadata parameter (see [OpenID Connect Discovery 1.0]), then RPs SHOULD assume that the issuer is a multi-tenant OP using a single issuer identifier and SHOULD expect the `tenant` claim to be present in ID Tokens. The `tenant` claim value MUST be one of the allowed values for the corresponding OP model as specified in the table in Section "tenant".
 
 ## OP Tenant Communication
 

--- a/openid-connect-enterprise-extensions-1_0.md
+++ b/openid-connect-enterprise-extensions-1_0.md
@@ -435,7 +435,7 @@ The following table summarizes OP tenancy models:
 | Multi-tenant OP (single issuer) | Single `iss` shared across tenants, single metadata endpoint, single signing keys | `public`: `iss` + `tenant` + `sub` unique<br/>`pairwise`: `iss` + `tenant` + `client_id` + `sub` unique | `tenant` claim in ID Token (see [Section "ID Token Claims"](#id-token-claims)) |
 | Multi-tenant OP (tenant-specific issuers) | Each tenant has own `iss`, metadata endpoint, and signing keys | `public`: `iss` + `sub` unique (per tenant)<br/>`pairwise`: `iss` + `client_id` + `sub` unique (per tenant) | `iss` value identifies tenant |
 
-- **Discovery**: If an OP publishes support for the `tenant` claim in the `claims_supported` metadata parameter (see [OpenID Connect Discovery 1.0]), then RPs SHOULD assume that the issuer is a multi-tenant OP using a single issuer identifier and SHOULD expect the `tenant` claim to be present in ID Tokens. The `tenant` claim value MUST be one of the allowed values for the corresponding OP model as specified in the table in [Section "tenant"](#tenant).
+- **Discovery**: If an OP publishes support for the `tenant` claim in the `claims_supported` metadata parameter (see [OpenID Connect Discovery 1.0]), then RPs SHOULD assume that the issuer is a multi-tenant OP using a single issuer identifier and SHOULD expect the `tenant` claim to be present in ID Tokens with a value of `personal` or a unique tenant identifier, as specified in [Section "tenant"](#tenant).
 
 ## OP Tenant Communication
 

--- a/openid-connect-enterprise-extensions-1_0.md
+++ b/openid-connect-enterprise-extensions-1_0.md
@@ -686,6 +686,7 @@ specification.
 
    -02
 
+   * updated `tenant` claim rules
    * added `aud_tenant` claim
    * added `client_tenant` authentication request parameter
    * added `tenants` client registration parameter

--- a/openid-connect-enterprise-extensions-1_0.md
+++ b/openid-connect-enterprise-extensions-1_0.md
@@ -1,5 +1,5 @@
 %%%
-title = "OpenID Connect Enterprise Extensions 1.0 - draft 01"
+title = "OpenID Connect Enterprise Extensions 1.0 - draft 02"
 abbrev = "openid-connect-enterprise-extensions"
 ipr = "none"
 workgroup = "OpenID Connect"
@@ -74,9 +74,234 @@ This specification defines the following terms:
 
 - **Tenant**: A logically isolated entity that represents a distinct organizational or administrative boundary. A tenant may contain accounts managed by individuals or by an organization. Both an OpenID Provider (OP) and a Relying Party (RP) may have a single tenant or multiple tenants. When referring to a tenant within an OP, it is called an "OP tenant". When referring to a tenant within an RP, it is called an "RP tenant".
 
+# ID Token Claims
+
+An ID Token is defined in Section 2 of [OpenID Connect Core 1.0](#OpenID Connect Core 1.0). 
+
+Following are OPTIONAL claims that may be included in an ID Token:
+
+## session_expiry
+
+The `session_expiry` claim is a JSON integer that represents the Unix timestamp (seconds since epoch) indicating when a session created from the ID Token MUST expire. 
+
+## tenant
+
+The `tenant` claim is a JSON string that represents an OP tenant identifier. This claim is OPTIONAL and MAY be included in ID Tokens.
+
+- **Single-tenant OPs**: Single-tenant OPs SHOULD omit the `tenant` claim.
+
+- **Multi-tenant OPs using a single issuer**: Multi-tenant OPs using a single issuer identifier SHOULD include the `tenant` claim to identify the OP tenant. The value MUST be a stable, opaque to the RP, OP unique identifier or a well known special value described below.
+
+  - The combination of `iss`, `tenant`, and `sub` MUST be unique across all OP tenants.
+  - If the OP uses `pairwise` subject identifiers, the same user MAY have the same `sub` for the same `client_id` regardless of OP tenant. The `tenant` claim SHOULD be included in the uniqueness requirement (`iss` + `tenant` + `sub`) to disambiguate subjects across tenants.
+  - If the OP uses `public` subject identifiers, the `sub` value MUST be the same across all RPs/clients and all OP tenants. The `tenant` claim MUST be included in the uniqueness requirement (`iss` + `tenant` + `sub`) to disambiguate subjects across tenants.
+
+- **Multi-tenant OPs using tenant-specific issuer identifiers**: Multi-tenant OPs using tenant-specific issuer identifiers SHOULD omit the `tenant` claim since the issuer identifier itself identifies the tenant.
+
+  - Each tenant issuer identifier MUST be a valid URL per [OpenID Connect Core 1.0] Section 2.
+  - The combination of `iss` and `sub` MUST be unique per tenant.
+  - If the OP uses `pairwise` subject identifiers, the `sub` value MUST differ across `client_id` values within each tenant. The combination of `iss` + `client_id` + `sub` MUST be unique across all tenants.
+  - If the OP uses `public` subject identifiers, the `sub` value MUST be the same across all RPs/clients within each tenant. The `sub` value MAY be the same across tenants, but the combination of `iss` + `sub` MUST be unique across all tenants.
+
+- **Special values**: The `tenant` claim MAY have the well-known value `personal` or `organization` instead of a unique identifier.
+  - `personal`: Indicates that accounts are managed by individuals rather than by a specific organizational tenant.
+  - `organization`: Indicates that accounts are managed by an organization.
+
+For multi-tenant OPs using tenant-specific issuer identifiers, if the `tenant` claim is present and does not match the tenant identified by the `iss` value, the RP SHOULD treat this as an error condition.
+
+- **Discovery**: If an OP publishes support for the `tenant` claim in the `claims_supported` metadata parameter (see [OpenID Connect Discovery 1.0]), then RPs SHOULD assume that the issuer supports multiple tenants and SHOULD expect the `tenant` claim to be present in ID Tokens.
+
+## aud_sub
+
+The `aud_sub` claim is an opaque JSON string that represents the identifier the RP has for the account. This claim is OPTIONAL. How the OP acquires the `aud_sub` and how the OP account and RP account linking is established is out of scope of this specification.
+
+The `aud_sub` value MUST be unique within the context of the `client_id`.
+
+When the `aud_tenant` claim is present, the `aud_sub` claim represents the account identifier within the context of that specific RP tenant. See Section "aud_tenant" for uniqueness requirements.
+
+## aud_tenant
+
+The `aud_tenant` claim is a JSON string that represents an RP tenant identifier. This claim is OPTIONAL and is only included when the RP is multi-tenant and the OP knows the RP tenant identifier (see Appendix A for how the RP communicates its tenant identifier to the OP).
+
+When the RP provides the `client_tenant` authentication request parameter, the `aud_tenant` claim value MUST be the same value that the RP provided in that parameter. When the OP determines the RP tenant identifier through other means (e.g., `domain_hint`, `login_hint`, default tenant selection, or end-user selection), the `aud_tenant` claim value MUST be a valid RP tenant identifier for the client. The value is opaque to the OP (the OP does not need to understand its semantic meaning). The value MUST be a stable identifier that is unique within the context of the `client_id` used in the authentication request, ensuring that when multiple RP tenants share the same `client_id`, each tenant can be uniquely identified.
+
+When `aud_tenant` is present, the `aud_sub` claim represents the identifier the RP has for the account within the context of that specific RP tenant. The combination of `aud` + `aud_tenant` and `aud_sub` MUST be unique within the RP.
+
+# Authentication Request Parameters
+
+An Authentication request is defined in Section 3.1.2.1 of [OpenID Connect Core 1.0].
+
+Following are OPTIONAL parameters that may be included in an Authentication Request:
+
+## domain_hint
+
+The `domain_hint` parameter provides a hint for the OP to determine which OP tenant to present to the user to authenticate to. This parameter is typically a domain name or email domain (e.g., `example.com`) that helps the OP identify the appropriate tenant. The `domain_hint` parameter is a user experience hint and is not guaranteed to uniquely identify a tenant.
+
+## tenant
+
+The `tenant` parameter is the explicit OP tenant identifier value that corresponds to the `tenant` claim the RP would like included in the ID Token. This parameter takes precedence over `domain_hint` when both are present. 
+
+The `tenant` parameter value MUST match one of the following:
+- The value `personal` to indicate the RP would like the user to use an account managed by the user (personal account)
+- The value `organization` to indicate the RP would like the user to use an account managed by an organization (organizational account)
+- A stable, opaque OP tenant identifier value for multi-tenant OPs
+
+If the `tenant` parameter value does not match any OP tenant, the OP SHOULD return an `invalid_request` error or proceed with the authentication using the OP's default tenant selection logic. The specific behavior is implementation-dependent.
+
+## client_tenant
+
+The `client_tenant` parameter is an OPTIONAL parameter that the RP includes to communicate its RP tenant identifier to the OP. This parameter is used when the RP is multi-tenant and uses a shared `client_id` across multiple RP tenants (see Appendix A for details on multi-tenant RP models).
+
+The client MAY register allowed tenants using the `tenants` client registration parameter. When the `client_tenant` authentication request parameter is provided, the OP SHOULD validate that the `client_tenant` value corresponds to a valid RP tenant identifier that was registered for this client.
+
+The `client_tenant` parameter value MUST be a stable identifier that is unique within the context of the `client_id` used in the authentication request, ensuring that when multiple RP tenants share the same `client_id`, each tenant can be uniquely identified. The value is opaque to the OP (the OP does not need to understand its semantic meaning) and MUST be echoed back in the `aud_tenant` claim.
+
+The OP MUST treat the `redirect_uri` as opaque and MUST NOT attempt to identify an RP tenant from a specific URL endpoint or pattern.
+
+When the RP uses only the `state` parameter or session context for tenant routing and does not provide a `client_tenant` parameter, the OP MUST omit the `aud_tenant` claim from the ID Token.
+
+If the `client_tenant` parameter is provided but the OP cannot determine the corresponding RP tenant (e.g., the value doesn't match any registered tenant identifier for the `client_id`), the OP SHOULD return an `invalid_request` error with an appropriate error description.
+
+If an RP is multi-tenant and uses a shared `client_id` but does not provide a `client_tenant` parameter, the OP MAY:
+- Attempt to resolve the RP tenant identifier using other available information (e.g., `domain_hint`, `login_hint`)
+- Select a default tenant for the client or fallback behavior (implementation-dependent)
+- Prompt the end-user to select a valid tenant for the client
+- Return an `invalid_request` error indicating that tenant identification is required
+
+If the OP successfully determines the RP tenant identifier through any of these means, it SHOULD include it in the `aud_tenant` claim of the ID Token.
+
+If the OP does not support RP tenant identification and receives a `client_tenant` parameter, the OP SHOULD ignore the parameter and MUST omit the `aud_tenant` claim from the ID Token.
+
+# Client Registration Parameters
+
+Client registration is defined in [OpenID Connect Dynamic Client Registration 1.0].
+
+Following are OPTIONAL client registration parameters that may be included during client registration:
+
+## tenants
+
+The `tenants` parameter is a JSON array of strings that represents RP tenant identifiers. This parameter is OPTIONAL and MAY be included during client registration.
+
+When the `client_tenant` authentication request parameter is provided, the OP MAY use the `tenants` client registration parameter to validate that the `client_tenant` value corresponds to a valid RP tenant identifier that was registered for this client. The OP can use this information to apply RP tenant-specific policies or to validate the authentication request.
+
+If an RP registers the `tenants` client registration parameter, OPs SHOULD assume the RP is multi-tenant.
+
+For example:
+
+```json
+{
+  "client_id": "rp-shared-abcde",
+  "redirect_uris": ["https://app.example.com/callback"],
+  "tenants": ["acme-corp-tenant-id", "widgets-inc-tenant-id"]
+}
+```
+
+# Login from a Third Party Parameters
+
+Initiating a login from a third party and a login initiation endpoint are defined in Section 4 of [OpenID Connect Core 1.0].
+
+Following are OPTIONAL parameters that may be included in request to the login initiation endpoint:
+
+## client_id
+
+The `client_id` value the RP should use when making the Authentication Request. This allows a multi-tenant application that hosts multiple tenants, each represented by a different `client_id`, to know which `client_id` to use.
+
+## domain_hint
+
+The `domain_hint` value to be included in the Authentication Request.
+
+## tenant
+
+The `tenant` value to be included in the Authentication Request.
+
+## client_tenant
+
+The `client_tenant` value to be included in the Authentication Request.
+
+# Security Considerations
+
+## OP Security Considerations
+
+### Tenant Isolation
+
+OPs MUST ensure strict isolation between tenants. An authenticated user from one OP tenant MUST NOT be able to obtain tokens containing a different tenant's identifier. The OP MUST validate that the `tenant` claim (see Section "ID Token Claims") in issued ID Tokens accurately reflects the tenant context in which the user authenticated.
+
+### Client Tenant Validation
+
+When the OP receives a `client_tenant` authentication request parameter (see Section "Authentication Request Parameters"), the OP SHOULD validate that the value corresponds to a registered RP tenant identifier for the given `client_id`. If the OP has registered the `tenants` client registration parameter (see Section "Client Registration Parameters") for the client, the OP SHOULD reject requests where `client_tenant` is not in the registered list.
+
+Failure to validate the `client_tenant` parameter could allow an attacker to request tokens for arbitrary RP tenants, potentially bypassing RP tenant-specific policies configured at the OP.
+
+### Subject Identifier Collision
+
+Multi-tenant OPs MUST ensure that subject identifiers are unambiguous across tenants to prevent account confusion where an RP incorrectly links accounts from different OP tenants.
+
+For multi-tenant OPs using a single issuer (see Appendix A), the OP MUST ensure that subject identifiers are unambiguous across tenants. If the same `sub` value could exist in multiple OP tenants, the OP MUST include the `tenant` claim (see Section "ID Token Claims") in the ID Token to enable RPs to correctly identify the account. The combination of `iss` + `tenant` + `sub` (for public subject identifiers) or `iss` + `tenant` + `client_id` + `sub` (for pairwise subject identifiers) MUST be unique across all tenants (see Appendix A for detailed requirements).
+
+For multi-tenant OPs using tenant-specific issuer identifiers (see Appendix A), the OP MUST ensure that the combination of `iss` + `sub` (for public subject identifiers) or `iss` + `client_id` + `sub` (for pairwise subject identifiers) is unique across all tenants. Since each tenant has a different issuer identifier, the OIDC Core requirement that `sub` is unique within `iss` already ensures tenant isolation. However, the OP MUST ensure uniqueness across all tenants, regardless of whether a client is shared across tenants or unique per tenant (see Appendix A for detailed requirements).
+
+### Token Injection Prevention
+
+OPs SHOULD implement measures to prevent token injection attacks where an attacker attempts to replay tokens across tenant boundaries. This includes ensuring that tokens issued for one tenant context cannot be used to authenticate to a different tenant.
+
+## RP Security Considerations
+
+### Tenant Claim Validation
+
+When an RP expects to receive the `tenant` claim (see Section "ID Token Claims") (e.g., when authenticating to a multi-tenant OP using a single issuer, as described in Appendix A), the RP MUST validate that the `tenant` claim is present in the ID Token. If the RP has prior knowledge of the expected tenant (e.g., from a previous authentication or configuration), the RP SHOULD validate that the received `tenant` claim matches the expected value.
+
+Failure to validate the `tenant` claim could result in:
+- Account confusion where users from different OP tenants are incorrectly linked
+- Privilege escalation if tenant-specific access controls are bypassed
+
+### aud_tenant Claim Validation
+
+When an RP sends the `client_tenant` authentication request parameter (see Section "Authentication Request Parameters"), the RP MUST validate that the returned `aud_tenant` claim (see Section "ID Token Claims") matches the value sent in the request. If the `aud_tenant` claim is missing or contains a different value, the RP MUST reject the ID Token.
+
+This validation prevents an attacker from obtaining a token intended for one RP tenant and using it to authenticate to a different RP tenant. See Appendix A for details on how the `client_tenant` parameter relates to the `aud_tenant` claim.
+
+### Account Identifier Uniqueness
+
+RPs MUST use the complete set of identifying claims when linking accounts:
+- For multi-tenant OPs using a single issuer (see Appendix A): `iss` + `tenant` (see Section "ID Token Claims") + `sub`
+- For multi-tenant OPs using tenant-specific issuers (see Appendix A): `iss` + `sub`
+- For multi-tenant RPs with shared `client_id` (see Appendix A): `aud` + `aud_tenant` (see Section "ID Token Claims") + `aud_sub` (see Section "ID Token Claims") (when present)
+
+Using only a subset of these claims (e.g., only `sub`) could result in incorrectly linking accounts from different tenants.
+
+### Cross-Tenant Request Forgery
+
+Multi-tenant RPs MUST ensure that authentication responses are processed in the correct tenant context. When using the `state` parameter or session context for tenant routing, the RP MUST validate that the response is processed by the same tenant that initiated the request. Failure to do so could allow an attacker to initiate authentication in one RP tenant and have the response processed in a different RP tenant.
+
+# Privacy Considerations
+
+*To be completed.*
+
+# IANA Considerations
+
+*To be completed.*
+
+# References
+
+## Normative References
+
+- **[RFC2119]** Bradner, S. "Key words for use in RFCs to Indicate Requirement Levels," *RFC 2119*, March 1997.
+- **[OpenID Connect Core 1.0]** – "OpenID Connect Core 1.0 incorporating errata set 2," available at <https://openid.net/specs/openid-connect-core-1_0.html>.
+- **[OpenID Connect Discovery 1.0]** – "OpenID Connect Discovery 1.0 incorporating errata set 2," available at <https://openid.net/specs/openid-connect-discovery-1_0.html>.
+- **[OpenID Connect Dynamic Client Registration 1.0]** – "OpenID Connect Dynamic Client Registration 1.0 incorporating errata set 2," available at <https://openid.net/specs/openid-connect-registration-1_0.html>. 
+
+## Informative References
+
+- **IANA JSON Web Token Claims Registry**, available at <https://www.iana.org/assignments/jwt/jwt.xhtml>.
+- **IANA OAuth Parameters**, available at <https://www.iana.org/assignments/oauth-parameters/oauth-parameters.xhtml#client-metadata>.
+
+{backmatter}
+
 # Enterprise Tenancy Models
 
-This section explains the relationships between issuer, client, and tenant for an OpenID Provider (OP) and Relying Party (RP). Understanding these models is essential for correctly implementing the claims and parameters defined in this specification.
+This appendix is non-normative.
+
+This appendix explains the relationships between issuer, client, and tenant for an OpenID Provider (OP) and Relying Party (RP). Understanding these models is helpful for correctly implementing the claims and parameters defined in this specification.
 
 The following diagram illustrates the relationship between OP tenants, RP tenants, and accounts:
 
@@ -280,11 +505,8 @@ An RP can be single-tenant or multi-tenant:
   ```
 
 - **Multi-tenant RP**: The RP has multiple tenants. Each tenant represents a distinct organizational or administrative boundary within the RP. Accounts are specific to the RP tenant. When an RP is multi-tenant, it needs to structure its client registration with the OP so that the OP can identify which RP tenant is making an authentication request. Multi-tenant RPs can use one of the following approaches:
-
   - **Unique Client per Tenant**: Each RP tenant has its own unique `client_id` registered with the OP issuer.
-
     - **Registration**: Each RP tenant registers its own unique `client_id` with the OP issuer.
-
     - **Account Identifier Uniqueness**: Account identifiers (such as `aud_sub` if present) MUST be unique within the context of that `client_id`.
 
     For example:
@@ -308,9 +530,7 @@ An RP can be single-tenant or multi-tenant:
       ```
 
   - **Shared Client for all Tenants**: Multiple RP tenants share a single `client_id` registered with the OP.
-
     - **Registration**: All RP tenants share a single `client_id` registered with the OP. The RP MAY register the `tenants` client registration parameter (see Section "Client Registration Parameters") as a JSON array of strings containing the RP tenant identifiers.
-
     - **Account Identifier Uniqueness**: When both `aud_tenant` and `aud_sub` are present, their combination MUST be unique for a given `aud` (client identifier) within the RP. This ensures that account identifiers are unambiguous within the context of the RP, even when the same `aud_sub` value might exist in different RP tenants.
 
     For example:
@@ -325,6 +545,7 @@ An RP can be single-tenant or multi-tenant:
       }
       ```
     - RP tenant "Widgets Inc" is identified by the `aud_tenant` claim in the ID Token:
+
       ```json
       {
         "iss": "https://idp.example.com",
@@ -399,210 +620,6 @@ The following diagram illustrates RP tenant communication flow:
 └─────────────────────┘                    └─────────────────────┘
 ```
 
-# ID Token Claims
-
-An ID Token is defined in Section 2 of [OpenID Connect Core 1.0](#OpenID Connect Core 1.0). 
-
-Following are OPTIONAL claims that may be included in an ID Token:
-
-## session_expiry
-
-The `session_expiry` claim is a JSON integer that represents the Unix timestamp (seconds since epoch) indicating when a session created from the ID Token MUST expire. 
-
-## tenant
-
-The `tenant` claim is a JSON string that represents an OP tenant identifier. This claim is OPTIONAL and MAY be included in ID Tokens.
-
-- **Single-tenant OPs**: Single-tenant OPs SHOULD omit the `tenant` claim.
-
-- **Multi-tenant OPs using a single issuer**: Multi-tenant OPs using a single issuer identifier SHOULD include the `tenant` claim to identify the OP tenant. The value MUST be a stable, opaque to the RP, OP unique identifier or a well known special value described below.
-
-- **Multi-tenant OPs using tenant-specific issuer identifiers**: Multi-tenant OPs using tenant-specific issuer identifiers SHOULD omit the `tenant` claim since the issuer identifier itself identifies the tenant.
-
-- **Special values**: The `tenant` claim MAY have the well-known value `personal` or `organization` instead of a unique identifier.
-  - `personal`: Indicates that accounts are managed by individuals rather than by a specific organizational tenant.
-  - `organization`: Indicates that accounts are managed by an organization.
-
-For multi-tenant OPs using tenant-specific issuer identifiers, if the `tenant` claim is present and does not match the tenant identified by the `iss` value, the RP SHOULD treat this as an error condition.
-
-## aud_sub
-
-The `aud_sub` claim is an opaque JSON string that represents the identifier the RP has for the account. This claim is OPTIONAL. How the OP acquires the `aud_sub` and how the OP account and RP account linking is established is out of scope of this specification.
-
-When the `aud_tenant` claim is present, the `aud_sub` claim represents the account identifier within the context of that specific RP tenant. See Section "aud_tenant" for uniqueness requirements.
-
-## aud_tenant
-
-The `aud_tenant` claim is a JSON string that represents an RP tenant identifier. This claim is OPTIONAL and is only included when the RP is multi-tenant and the OP knows the RP tenant identifier (see Section "RP Tenant Communication" for how the RP communicates its tenant identifier to the OP).
-
-When the RP provides the `client_tenant` authentication request parameter, the `aud_tenant` claim value MUST be the same value that the RP provided in that parameter. When the OP determines the RP tenant identifier through other means (e.g., `domain_hint`, `login_hint`, default tenant selection, or end-user selection), the `aud_tenant` claim value MUST be a valid RP tenant identifier for the client. The value is opaque to the OP (the OP does not need to understand its semantic meaning). The value MUST be a stable identifier that is unique within the context of the `client_id` used in the authentication request, ensuring that when multiple RP tenants share the same `client_id`, each tenant can be uniquely identified.
-
-When `aud_tenant` is present, the `aud_sub` claim represents the identifier the RP has for the account within the context of that specific RP tenant. The combination of `aud` + `aud_tenant` and `aud_sub` MUST be unique within the RP.
-
-# Authentication Request Parameters
-
-An Authentication request is defined in Section 3.1.2.1 of [OpenID Connect Core 1.0].
-
-Following are OPTIONAL parameters that may be included in an Authentication Request:
-
-## domain_hint
-
-The `domain_hint` parameter provides a hint for the OP to determine which OP tenant to present to the user to authenticate to. This parameter is typically a domain name or email domain (e.g., `example.com`) that helps the OP identify the appropriate tenant. The `domain_hint` parameter is a user experience hint and is not guaranteed to uniquely identify a tenant.
-
-## tenant
-
-The `tenant` parameter is the explicit OP tenant identifier value that corresponds to the `tenant` claim the RP would like included in the ID Token. This parameter takes precedence over `domain_hint` when both are present. 
-
-The `tenant` parameter value MUST match one of the following:
-- The value `personal` to indicate the RP would like the user to use an account managed by the user (personal account)
-- The value `organization` to indicate the RP would like the user to use an account managed by an organization (organizational account)
-- A stable, opaque OP tenant identifier value for multi-tenant OPs
-
-If the `tenant` parameter value does not match any OP tenant, the OP SHOULD return an `invalid_request` error or proceed with the authentication using the OP's default tenant selection logic. The specific behavior is implementation-dependent.
-
-## client_tenant
-
-The `client_tenant` parameter is an OPTIONAL parameter that the RP includes to communicate its RP tenant identifier to the OP. This parameter is used when the RP is multi-tenant and uses a shared `client_id` across multiple RP tenants (see Section "RP Tenancy" for details on multi-tenant RP models).
-
-The client MAY register allowed tenants using the `tenants` client registration parameter. When the `client_tenant` authentication request parameter is provided, the OP SHOULD validate that the `client_tenant` value corresponds to a valid RP tenant identifier that was registered for this client.
-
-The `client_tenant` parameter value MUST be a stable identifier that is unique within the context of the `client_id` used in the authentication request, ensuring that when multiple RP tenants share the same `client_id`, each tenant can be uniquely identified. The value is opaque to the OP (the OP does not need to understand its semantic meaning) and MUST be echoed back in the `aud_tenant` claim.
-
-If the `client_tenant` parameter is provided but the OP cannot determine the corresponding RP tenant (e.g., the value doesn't match any registered tenant identifier for the `client_id`), the OP SHOULD return an `invalid_request` error with an appropriate error description.
-
-If an RP is multi-tenant and uses a shared `client_id` but does not provide a `client_tenant` parameter, the OP MAY:
-- Attempt to resolve the RP tenant identifier using other available information (e.g., `domain_hint`, `login_hint`)
-- Select a default tenant for the client or fallback behavior (implementation-dependent)
-- Prompt the end-user to select a valid tenant for the client
-- Return an `invalid_request` error indicating that tenant identification is required
-
-If the OP successfully determines the RP tenant identifier through any of these means, it SHOULD include it in the `aud_tenant` claim of the ID Token.
-
-If the OP does not support RP tenant identification and receives a `client_tenant` parameter, the OP SHOULD ignore the parameter and MUST omit the `aud_tenant` claim from the ID Token.
-
-# Client Registration Parameters
-
-Client registration is defined in [OpenID Connect Dynamic Client Registration 1.0].
-
-Following are OPTIONAL client registration parameters that may be included during client registration:
-
-## tenants
-
-The `tenants` parameter is a JSON array of strings that represents RP tenant identifiers. This parameter is OPTIONAL and MAY be included during client registration.
-
-When the `client_tenant` authentication request parameter is provided, the OP MAY use the `tenants` client registration parameter to validate that the `client_tenant` value corresponds to a valid RP tenant identifier that was registered for this client. The OP can use this information to apply RP tenant-specific policies or to validate the authentication request.
-
-For example:
-
-```json
-{
-  "client_id": "rp-shared-abcde",
-  "redirect_uris": ["https://app.example.com/callback"],
-  "tenants": ["acme-corp-tenant-id", "widgets-inc-tenant-id"]
-}
-```
-
-# Login from a Third Party Parameters
-
-Initiating a login from a third party and a login initiation endpoint are defined in Section 4 of [OpenID Connect Core 1.0].
-
-Following are OPTIONAL parameters that may be included in request to the login initiation endpoint:
-
-## client_id
-
-The `client_id` value the RP should use when making the Authentication Request. This allows a multi-tenant application that hosts multiple tenants, each represented by a different `client_id`, to know which `client_id` to use.
-
-## domain_hint
-
-The `domain_hint` value to be included in the Authentication Request.
-
-## tenant
-
-The `tenant` value to be included in the Authentication Request.
-
-## client_tenant
-
-The `client_tenant` value to be included in the Authentication Request.
-
-# Security Considerations
-
-## OP Security Considerations
-
-### Tenant Isolation
-
-OPs MUST ensure strict isolation between tenants. An authenticated user from one OP tenant MUST NOT be able to obtain tokens containing a different tenant's identifier. The OP MUST validate that the `tenant` claim (see Section "ID Token Claims") in issued ID Tokens accurately reflects the tenant context in which the user authenticated.
-
-### Client Tenant Validation
-
-When the OP receives a `client_tenant` authentication request parameter (see Section "Authentication Request Parameters"), the OP SHOULD validate that the value corresponds to a registered RP tenant identifier for the given `client_id`. If the OP has registered the `tenants` client registration parameter (see Section "Client Registration Parameters") for the client, the OP SHOULD reject requests where `client_tenant` is not in the registered list.
-
-Failure to validate the `client_tenant` parameter could allow an attacker to request tokens for arbitrary RP tenants, potentially bypassing RP tenant-specific policies configured at the OP.
-
-### Subject Identifier Collision
-
-Multi-tenant OPs MUST ensure that subject identifiers are unambiguous across tenants to prevent account confusion where an RP incorrectly links accounts from different OP tenants.
-
-For multi-tenant OPs using a single issuer (see Section "OP Tenancy"), the OP MUST ensure that subject identifiers are unambiguous across tenants. If the same `sub` value could exist in multiple OP tenants, the OP MUST include the `tenant` claim (see Section "ID Token Claims") in the ID Token to enable RPs to correctly identify the account. The combination of `iss` + `tenant` + `sub` (for public subject identifiers) or `iss` + `tenant` + `client_id` + `sub` (for pairwise subject identifiers) MUST be unique across all tenants (see Section "OP Tenancy" for detailed requirements).
-
-For multi-tenant OPs using tenant-specific issuer identifiers (see Section "OP Tenancy"), the OP MUST ensure that the combination of `iss` + `sub` (for public subject identifiers) or `iss` + `client_id` + `sub` (for pairwise subject identifiers) is unique across all tenants. Since each tenant has a different issuer identifier, the OIDC Core requirement that `sub` is unique within `iss` already ensures tenant isolation. However, the OP MUST ensure uniqueness across all tenants, regardless of whether a client is shared across tenants or unique per tenant (see Section "OP Tenancy" for detailed requirements).
-
-### Token Injection Prevention
-
-OPs SHOULD implement measures to prevent token injection attacks where an attacker attempts to replay tokens across tenant boundaries. This includes ensuring that tokens issued for one tenant context cannot be used to authenticate to a different tenant.
-
-## RP Security Considerations
-
-### Tenant Claim Validation
-
-When an RP expects to receive the `tenant` claim (see Section "ID Token Claims") (e.g., when authenticating to a multi-tenant OP using a single issuer, as described in Section "OP Tenancy"), the RP MUST validate that the `tenant` claim is present in the ID Token. If the RP has prior knowledge of the expected tenant (e.g., from a previous authentication or configuration), the RP SHOULD validate that the received `tenant` claim matches the expected value.
-
-Failure to validate the `tenant` claim could result in:
-- Account confusion where users from different OP tenants are incorrectly linked
-- Privilege escalation if tenant-specific access controls are bypassed
-
-### aud_tenant Claim Validation
-
-When an RP sends the `client_tenant` authentication request parameter (see Section "Authentication Request Parameters"), the RP MUST validate that the returned `aud_tenant` claim (see Section "ID Token Claims") matches the value sent in the request. If the `aud_tenant` claim is missing or contains a different value, the RP MUST reject the ID Token.
-
-This validation prevents an attacker from obtaining a token intended for one RP tenant and using it to authenticate to a different RP tenant. See Section "RP Tenant Communication" for details on how the `client_tenant` parameter relates to the `aud_tenant` claim.
-
-### Account Identifier Uniqueness
-
-RPs MUST use the complete set of identifying claims when linking accounts:
-- For multi-tenant OPs using a single issuer (see Section "OP Tenancy"): `iss` + `tenant` (see Section "ID Token Claims") + `sub`
-- For multi-tenant OPs using tenant-specific issuers (see Section "OP Tenancy"): `iss` + `sub`
-- For multi-tenant RPs with shared `client_id` (see Section "RP Tenancy"): `aud` + `aud_tenant` (see Section "ID Token Claims") + `aud_sub` (see Section "ID Token Claims") (when present)
-
-Using only a subset of these claims (e.g., only `sub`) could result in incorrectly linking accounts from different tenants.
-
-### Cross-Tenant Request Forgery
-
-Multi-tenant RPs MUST ensure that authentication responses are processed in the correct tenant context. When using the `state` parameter or session context for tenant routing, the RP MUST validate that the response is processed by the same tenant that initiated the request. Failure to do so could allow an attacker to initiate authentication in one RP tenant and have the response processed in a different RP tenant.
-
-# Privacy Considerations
-
-*To be completed.*
-
-# IANA Considerations
-
-*To be completed.*
-
-# References
-
-## Normative References
-
-- **[RFC2119]** Bradner, S. "Key words for use in RFCs to Indicate Requirement Levels," *RFC 2119*, March 1997.
-- **[OpenID Connect Core 1.0]** – "OpenID Connect Core 1.0 incorporating errata set 2," available at <https://openid.net/specs/openid-connect-core-1_0.html>.
-- **[OpenID Connect Discovery 1.0]** – "OpenID Connect Discovery 1.0 incorporating errata set 2," available at <https://openid.net/specs/openid-connect-discovery-1_0.html>.
-- **[OpenID Connect Dynamic Client Registration 1.0]** – "OpenID Connect Dynamic Client Registration 1.0 incorporating errata set 2," available at <https://openid.net/specs/openid-connect-registration-1_0.html>. 
-
-## Informative References
-
-- **IANA JSON Web Token Claims Registry**, available at <https://www.iana.org/assignments/jwt/jwt.xhtml>.
-- **IANA OAuth Parameters**, available at <https://www.iana.org/assignments/oauth-parameters/oauth-parameters.xhtml#client-metadata>.
-
-{backmatter}
-
 # Acknowledgements
 
 *To be updated.*
@@ -665,6 +682,5 @@ specification.
    * added `client_tenant` authentication request parameter
    * added `tenants` client registration parameter
    * added `client_tenant` to Login from a Third Party parameters
-   * added Tenancy Models section to describe OP and RP tenancy models and relationships
+   * added Tenancy Models appendix to describe OP and RP tenancy models and relationships
    * added Security Considerations
-

--- a/openid-connect-enterprise-extensions-1_0.md
+++ b/openid-connect-enterprise-extensions-1_0.md
@@ -7,7 +7,7 @@ keyword = ["security", "openid", "enterprise"]
 
 [seriesInfo]
 name = "Internet-Draft"
-value = "openid-connect-commands-1_0"
+value = "openid-connect-enterprise-extensions-1_0"
 status = "standard"
 
 [[author]]
@@ -30,22 +30,27 @@ organization="Independent"
 
 .# Abstract
 
-OpenID Connect 1.0 has become a popular choice for single sign on in enterprise use cases. To improve interoperability, OpenID Connect Enterprise Extensions specifies a number of common or desirable extensions to OpenID Connect.
-
-
+OpenID Connect 1.0 has become a popular choice for single sign-on in enterprise use cases. To improve interoperability, OpenID Connect Enterprise Extensions specifies a number of common or desirable extensions to OpenID Connect.
 
 {mainmatter}
 
 # Introduction
 
-
 OpenID Connect 1.0 is a widely adopted identity protocol that enables client applications, known as relying parties (RPs), to verify the identity of end-users based on authentication performed by a trusted service, the OpenID Provider (OP). 
 
 Initial adoption of OpenID Connect was by sites providing personal identity to applications. OpenID Connect has become a popular choice in enterprise use cases, and implementors have defined their own extensions for use cases that were not addressed in the original specification. 
 
-To improve interoperability between systems, OpenID Connect Enterprise Extensions specifies optional claims that may be included in an ID Token, optional parameters that may be included in an authentication request, and optional parameters optional parameters that may be included in when initiating login from a third party.
+To improve interoperability between systems, OpenID Connect Enterprise Extensions specifies optional claims that may be included in an ID Token, optional parameters that may be included in an authentication request, optional client registration parameters, and optional parameters that may be included when initiating login from a third party.
 
+Enterprise deployments of OpenID Connect often involve multi-tenancy on both sides of the protocol. An OpenID Provider (OP) may serve multiple organizations, each with their own users and policies. Similarly, a Relying Party (RP) may be a SaaS application serving multiple customer organizations, each requiring isolation of their users and data.
 
+This specification addresses three key challenges in multi-tenant deployments:
+
+**OP Tenant Identification**: When an OP serves multiple tenants using a single issuer identifier, the standard `iss` and `sub` claims are insufficient to uniquely identify a user across tenants. This specification defines the `tenant` claim to disambiguate users and the `tenant` and `domain_hint` authentication request parameters to allow RPs to specify which OP tenant to authenticate against.
+
+**RP Tenant Identification**: When an RP serves multiple tenants using a shared client registration, the OP has no standard way to know which RP tenant initiated the authentication request. This specification defines the `client_tenant` authentication request parameter and the `aud_tenant` ID Token claim to enable RPs to communicate their tenant context to the OP, allowing the OP to apply tenant-specific policies and echo the tenant identifier back in the token.
+
+**Account Linking**: When an OP maintains account linkages to RP accounts, the standard claims do not provide a mechanism to communicate the RP's account identifier. This specification defines the `aud_sub` claim to allow the OP to include the RP's account identifier in the ID Token, and the `aud_tenant` claim to scope that identifier to a specific RP tenant when applicable.
 
 ## Requirements Notation and Conventions
 
@@ -67,7 +72,332 @@ This specification defines the following terms:
 
 - **Account**: A set of claims about a user.
 
-- **Tenant**: A logically isolated entity within an OP that represents a distinct organizational or administrative boundary. An OP may have a single Tenant, or multiple Tenants. The Tenant may contain Accounts managed by individuals, or may contain Accounts managed by an organization.
+- **Tenant**: A logically isolated entity that represents a distinct organizational or administrative boundary. A tenant may contain accounts managed by individuals or by an organization. Both an OpenID Provider (OP) and a Relying Party (RP) may have a single tenant or multiple tenants. When referring to a tenant within an OP, it is called an "OP tenant". When referring to a tenant within an RP, it is called an "RP tenant".
+
+# Enterprise Tenancy Models
+
+This section explains the relationships between issuer, client, and tenant for an OpenID Provider (OP) and Relying Party (RP). Understanding these models is essential for correctly implementing the claims and parameters defined in this specification.
+
+The following diagram illustrates the relationship between OP tenants, RP tenants, and accounts:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                  OpenID Provider (OP)                       │
+│                                                             │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐       │
+│  │ OP Tenant A  │  │ OP Tenant B  │  │ OP Tenant C  │       │
+│  │              │  │              │  │              │       │
+│  │ ┌──────────┐ │  │ ┌──────────┐ │  │ ┌──────────┐ │       │
+│  │ │ Account 1│ │  │ │ Account 1│ │  │ │ Account 1│ │       │
+│  │ │ Account 2│ │  │ │ Account 2│ │  │ │ Account 2│ │       │
+│  │ └──────────┘ │  │ └──────────┘ │  │ └──────────┘ │       │
+│  └──────────────┘  └──────────────┘  └──────────────┘       │
+│                                                             │
+│  Identified by: `iss` + `tenant` (single issuer model)      │
+│  or by: `iss` alone (tenant-specific issuer model)          │
+└─────────────────────────────────────────────────────────────┘
+                            │
+                            │ Authentication
+                            │
+┌─────────────────────────────────────────────────────────────┐
+│                  Relying Party (RP)                         │
+│                                                             │
+│  ┌──────────────┐  ┌──────────────┐                         │
+│  │ RP Tenant X  │  │ RP Tenant Y  │                         │
+│  │              │  │              │                         │
+│  │ ┌──────────┐ │  │ ┌──────────┐ │                         │
+│  │ │ Account 1│ │  │ │ Account 1│ │                         │
+│  │ │ Account 2│ │  │ │ Account 2│ │                         │
+│  │ └──────────┘ │  │ └──────────┘ │                         │
+│  └──────────────┘  └──────────────┘                         │
+│                                                             │
+│  Identified by: `aud` (unique client per tenant)            │
+│  or by: `aud` + `aud_tenant` (shared client model)          │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## OP Tenancy
+
+An OP can have a single-tenant issuer or a multi-tenant issuer:
+
+- **Single-tenant OP**: The OP has a single tenant. All accounts are associated with this single tenant.
+
+  - **Issuer Configuration**: The issuer identifier (`iss`) uniquely identifies the OP. The OP has a single OP metadata endpoint and signing keys.
+
+  - **Subject Identifier Uniqueness**:
+    - If the OP uses `pairwise` subject identifiers, the `sub` value for the same user will differ across different `client_id` values.
+    - If the OP uses `public` subject identifiers, the `sub` value will be the same across all RPs/clients.
+
+  For example:
+
+  ```json
+  {
+    "iss": "https://idp.example.com",
+    "sub": "user123"
+  }
+  ```
+
+- **Multi-tenant OP**: The OP has multiple tenants. Multi-tenant OPs may use a single issuer identifier for all tenants, or tenant-specific issuer identifiers:
+  - **Single issuer for all tenants**: The OP uses one issuer identifier for all tenants, and the `tenant` claim (see Section "ID Token Claims") distinguishes between tenants.
+
+    - **Issuer Configuration**: All tenants share the same issuer identifier (`iss`), OP metadata endpoint, and signing keys.
+
+    - **Subject Identifier Uniqueness**:
+      - The combination of `iss` (issuer identifier), `tenant` (OP tenant identifier), and `sub` (subject identifier) MUST be unique across all tenants. This ensures that a subject identifier is unambiguous within the context of the OP, even when the same `sub` value might exist in different OP tenants.
+      - If the OP uses `pairwise` subject identifiers, the `sub` value for the same user MUST differ across different `client_id` values, but the same user MAY have the same `sub` value for the same `client_id` regardless of which OP tenant they authenticate to.  The OP is not required to have unique `pairwise` subject identifiers for clients that are shared across tenants per [OpenID Connect Core 1.0] Section 8.1. The `tenant` claim SHOULD be included in the uniqueness requirement (`iss` + `tenant` + `sub`) to disambiguate subjects across tenants.
+      - If the OP uses `public` subject identifiers, the `sub` value MUST be the same across all RPs/clients and all OP tenants. The `tenant` claim MUST be included in the uniqueness requirement (`iss` + `tenant` + `sub`) to disambiguate subjects across tenants.
+
+    For example:
+
+    Acme Corporation OP Tenant
+    ```json
+    {
+      "iss": "https://idp.example.com",
+      "tenant": "acme-corp",
+      "sub": "user123"
+    }
+    ```
+
+    Widgets Inc. OP Tenant
+    ```json
+    {
+      "iss": "https://idp.example.com",
+      "tenant": "widgets-inc",
+      "sub": "user456"
+    }
+    ```
+
+  - **Tenant-specific issuer identifiers**: The OP uses different issuer identifiers per tenant.
+
+    - **Issuer Configuration**: Each tenant has its own issuer identifier (`iss`), OP metadata endpoint, and signing keys. Each issuer identifier MUST be a valid URL per [OpenID Connect Core 1.0] Section 2.
+
+    - **Subject Identifier Uniqueness**:
+      - The combination of `iss` (issuer identifier) and `sub` (subject identifier) MUST be unique. Since each issuer identifier identifies a specific tenant, the OIDC Core requirement that `sub` is unique within `iss` already ensures tenant isolation.
+      - If the OP uses `pairwise` subject identifiers, the `sub` value for the same user MUST differ across different `client_id` values within each tenant. The combination of `iss` + `client_id` + `sub` MUST be unique across all tenants, regardless of whether a client is shared across tenants or unique per tenant, since each tenant has a different issuer identifier.
+      - If the OP uses `public` subject identifiers, the `sub` value MUST be the same across all RPs/clients within each tenant. The `sub` value MAY be the same across tenants (a global `sub`), but the combination of `iss` + `sub` MUST be unique across all tenants since each tenant has a different issuer identifier.
+
+    For example:
+
+    Acme Corporation OP Tenant
+    ```json
+    {
+      "iss": "https://acme-corp.idp.example.com",
+      "sub": "user123"
+    }
+    ```
+
+    Widgets Inc. OP Tenant
+    ```json
+    {
+      "iss": "https://widgets-inc.idp.example.com",
+      "sub": "user456"
+    }
+    ```
+
+The following table summarizes OP tenancy models:
+
+| Model | Issuer Configuration | Uniqueness Requirement | Tenant Identification |
+|-------|---------------------|------------------------|---------------------|
+| Single-tenant OP | Single `iss`, single metadata endpoint, single signing keys | `public`: `sub` unique within `iss`<br/>`pairwise`: `iss` + `client_id` + `sub` unique | Not applicable |
+| Multi-tenant OP (single issuer) | Single `iss` shared across tenants, single metadata endpoint, single signing keys | `public`: `iss` + `tenant` + `sub` unique<br/>`pairwise`: `iss` + `tenant` + `client_id` + `sub` unique | `tenant` claim in ID Token (see Section "ID Token Claims") |
+| Multi-tenant OP (tenant-specific issuers) | Each tenant has own `iss`, metadata endpoint, and signing keys | `public`: `iss` + `sub` unique (per tenant)<br/>`pairwise`: `iss` + `client_id` + `sub` unique (per tenant) | `iss` value identifies tenant |
+
+- **Discovery**: If an OP publishes support for the `tenant` claim in the `claims_supported` metadata parameter (see [OpenID Connect Discovery 1.0]), then RPs SHOULD assume that the issuer supports multiple tenants and SHOULD expect the `tenant` claim to be present in ID Tokens.
+
+## OP Tenant Communication
+
+When the OP uses tenant-specific issuer identifiers, the RP authenticates to the appropriate issuer endpoint (e.g., `https://acme-corp.idp.example.com`), and the tenant is identified by the issuer identifier itself. In that model, OP tenant communication is not required.
+
+The following applies only to multi-tenant OPs that use a single issuer for all tenants. For such OPs, the RP MAY specify which OP tenant it wants the user to authenticate to using one of the following mechanisms:
+
+- **`tenant` parameter**: The RP includes the `tenant` parameter in the authentication request with the OP tenant identifier value (e.g., `tenant=acme-corp`). When the OP receives this parameter, it SHOULD include the `tenant` claim in the ID Token with the same value. This is RECOMMENDED for RPs that know which `tenant` to make an authentication request to. See Section "Authentication Request Parameters" for details.
+
+- **`domain_hint` parameter**: The RP includes the `domain_hint` parameter with a domain name or email domain (e.g., `example.com`) that helps the OP identify the appropriate tenant. This is a user experience hint and is not guaranteed to uniquely identify a tenant. When both `tenant` and `domain_hint` are present, the `tenant` parameter takes precedence. If the OP cannot uniquely identify the tenant from `domain_hint` alone, the OP's tenant selection behavior is implementation-dependent. See Section "Authentication Request Parameters" for details.
+
+When the OP tenant is not specified by the RP (neither `tenant` nor `domain_hint` is provided, or `domain_hint` does not uniquely identify a tenant), the OP MAY:
+- Provide a selector to allow the end-user to pick the tenant during authentication
+- Default to a specific tenant for the `client_id` and/or `login_hint`
+- Reject the request with an `invalid_request` error
+
+The following diagram illustrates OP tenant communication flow:
+
+```
+┌─────────────────────┐                    ┌─────────────────────┐
+│         RP          │                    │         OP          │
+│                     │                    │                     │
+│ 1. RP determines    │                    │                     │
+│    desired OP       │                    │                     │
+│    tenant           │                    │                     │
+│    (from user       │                    │                     │
+│    input, config,   │                    │                     │
+│    etc.)            │                    │                     │
+│                     │                    │                     │
+│ 2. Authentication   │                    │                     │
+│    Request          │                    │                     │
+│    ├─ tenant=acme-  │                    │                     │
+│    │  corp          │                    │                     │
+│    │  (explicit)    │                    │                     │
+│    └─ OR            │                    │                     │
+│       domain_hint=  │                    │                     │
+│       acme.com      │                    │                     │
+│       (hint)        │                    │                     │
+│         │───────────────────────────────>│                     │
+│         │                                │                     │
+│         │                                │ 3. OP resolves      │
+│         │                                │    tenant context   │
+│         │                                │                     │
+│         │                                │ 4. User auth        │
+│         │                                │                     │
+│         │ 5. ID Token                    │                     │
+│         │    └─ tenant: "acme-corp"      │                     │
+│         │<───────────────────────────────│                     │
+│         │                                │                     │
+│ 6. RP validates     │                    │                     │
+│    tenant claim     │                    │                     │
+│    matches expected │                    │                     │
+│    tenant           │                    │                     │
+└─────────────────────┘                    └─────────────────────┘
+```
+
+## RP Tenancy
+
+An RP can be single-tenant or multi-tenant:
+
+- **Single-tenant RP**: The RP has a single tenant. All accounts are associated with this single tenant.
+
+  - **Registration**: The RP registers a single `client_id` with the OP issuer.
+
+  - **Account Identifier Uniqueness**: Account identifiers (such as `aud_sub` if present) MUST be unique within the context of that `client_id`.
+
+  For example:
+  ```json
+  {
+    "iss": "https://idp.example.com",
+    "sub": "user123",
+    "aud": "rp-single-tenant-xyz",
+    "aud_sub": "rp-account-123"
+  }
+  ```
+
+- **Multi-tenant RP**: The RP has multiple tenants. Each tenant represents a distinct organizational or administrative boundary within the RP. Accounts are specific to the RP tenant. When an RP is multi-tenant, it needs to structure its client registration with the OP so that the OP can identify which RP tenant is making an authentication request. Multi-tenant RPs can use one of the following approaches:
+
+  - **Unique Client per Tenant**: Each RP tenant has its own unique `client_id` registered with the OP issuer.
+
+    - **Registration**: Each RP tenant registers its own unique `client_id` with the OP issuer.
+
+    - **Account Identifier Uniqueness**: Account identifiers (such as `aud_sub` if present) MUST be unique within the context of that `client_id`.
+
+    For example:
+    - RP tenant "Acme Corp" uses `client_id`: `rp-acme-corp-12345`
+      ```json
+      {
+        "iss": "https://idp.example.com",
+        "sub": "user123",
+        "aud": "rp-acme-corp-12345",
+        "aud_sub": "acme-account-456"
+      }
+      ```
+    - RP tenant "Widgets Inc" uses `client_id`: `rp-widgets-inc-67890`
+      ```json
+      {
+        "iss": "https://idp.example.com",
+        "sub": "user123",
+        "aud": "rp-widgets-inc-67890",
+        "aud_sub": "widgets-account-789"
+      }
+      ```
+
+  - **Shared Client for all Tenants**: Multiple RP tenants share a single `client_id` registered with the OP.
+
+    - **Registration**: All RP tenants share a single `client_id` registered with the OP. The RP MAY register the `tenants` client registration parameter (see Section "Client Registration Parameters") as a JSON array of strings containing the RP tenant identifiers.
+
+    - **Account Identifier Uniqueness**: When both `aud_tenant` and `aud_sub` are present, their combination MUST be unique for a given `aud` (client identifier) within the RP. This ensures that account identifiers are unambiguous within the context of the RP, even when the same `aud_sub` value might exist in different RP tenants.
+
+    For example:
+    - All RP tenants share `client_id`: `rp-shared-abcde`
+    - RP tenant "Acme Corp" is identified by the `aud_tenant` claim in the ID Token:
+      ```json
+      {
+        "iss": "https://idp.example.com",
+        "sub": "user123",
+        "aud": "rp-shared-abcde",
+        "aud_tenant": "acme-corp-tenant-id"
+      }
+      ```
+    - RP tenant "Widgets Inc" is identified by the `aud_tenant` claim in the ID Token:
+      ```json
+      {
+        "iss": "https://idp.example.com",
+        "sub": "user456",
+        "aud": "rp-shared-abcde",
+        "aud_tenant": "widgets-inc-tenant-id"
+      }
+      ```
+
+The following table summarizes RP tenancy models:
+
+| Model | Registration | Account Identifier Uniqueness | Tenant Identification |
+|-------|--------------|------------------------------|----------------------|
+| Single-tenant RP | Single `client_id` registered with OP issuer | `aud_sub` unique within `client_id` | Not applicable |
+| Multi-tenant RP (unique client per tenant) | Each tenant has own `client_id` registered with OP issuer | `aud_sub` unique within `client_id` | `aud` identifies tenant |
+| Multi-tenant RP (shared client) | Single `client_id` shared across tenants, `tenants` parameter MAY be registered | `aud_tenant` + `aud_sub` unique within `aud` | `aud` + `aud_tenant` claim in ID Token (see Section "ID Token Claims") |
+
+- **Discovery**: If an RP supports multiple tenants and registers the `tenants` client registration parameter for the client, then OPs SHOULD assume the RP is multi-tenant.
+
+## RP Tenant Communication
+
+When an RP is multi-tenant and uses a shared `client_id`, the RP MAY communicate its tenant identifier to the OP, but is not required to do so. If the OP knows the RP tenant identifier, it SHOULD include it in the `aud_tenant` claim of the ID Token (see Section "ID Token Claims").
+
+The RP can communicate its tenant identifier using one of the following mechanisms:
+
+- **`client_tenant` authentication request parameter** (RECOMMENDED): The RP includes the `client_tenant` parameter in the authentication request with its tenant identifier value. This is explicit and unambiguous, allowing the OP to include the `aud_tenant` claim in the ID Token and apply RP tenant-specific policies (e.g., access control, consent requirements, authentication methods). When present, the OP MUST echo this value back in the `aud_tenant` claim. See Section "Authentication Request Parameters" for details.
+
+- **`state` parameter or session context**: RPs may include tenant identification information in the opaque `state` parameter of the OpenID Connect Authentication Request, or maintain tenant context via cookies or other session mechanisms. When the RP uses only this mechanism, the OP does not have access to the tenant identifier and MUST omit the `aud_tenant` claim from the ID Token. The OP cannot apply RP tenant-specific policies, and the RP MUST use implementation-specific mechanisms (such as parsing the `state` parameter or session context) to determine the tenant for routing the authentication response. This pattern is commonly used in practice.
+
+- **`redirect_uri`**: RPs may register a `redirect_uri` per tenant and include the specific tenant redirect_uri in the OpenID Connect Authentication Request. The OP MUST treat the `redirect_uri` as opaque and MUST NOT attempt to identify a tenant from a specific URL endpoint or pattern. This mechanism only enables RP-side tenant routing; the OP cannot apply RP tenant-specific policies using this approach.
+
+If the RP does not provide a `client_tenant` parameter and the OP cannot determine the RP tenant identifier from other mechanisms (such as `state` or `redirect_uri`), the OP MAY attempt to resolve the RP tenant using other available information (e.g., `domain_hint`, `login_hint`) or MAY select a default tenant for the client, or MAY prompt the end-user to select a valid tenant for the client. If the OP successfully determines the RP tenant identifier through any of these means, it SHOULD include it in the `aud_tenant` claim of the ID Token.
+
+The following diagram illustrates RP tenant communication flow:
+
+```
+┌─────────────────────┐                    ┌─────────────────────┐
+│         RP          │                    │         OP          │
+│                     │                    │                     │
+│ 1. RP identifies    │                    │                     │
+│    its tenant       │                    │                     │
+│    context          │                    │                     │
+│    (e.g., from URL, │                    │                     │
+│    session, config) │                    │                     │
+│                     │                    │                     │
+│ 2. Authentication   │                    │                     │
+│    Request          │                    │                     │
+│    └─ client_tenant=│                    │                     │
+│       acme-corp-    │                    │                     │
+│       tenant-id     │                    │                     │
+│         │───────────────────────────────>│                     │
+│         │                                │                     │
+│         │                                │ 3. OP validates     │
+│         │                                │    client_tenant    │
+│         │                                │    (if tenants      │
+│         │                                │    registered)      │
+│         │                                │                     │
+│         │                                │ 4. User auth        │
+│         │                                │                     │
+│         │ 5. ID Token                    │                     │
+│         │    └─ aud_tenant:              │                     │
+│         │        "acme-corp-tenant-id"   │                     │
+│         │<───────────────────────────────│                     │
+│         │                                │                     │
+│ 6. RP validates     │                    │                     │
+│    aud_tenant claim │                    │                     │
+│    matches          │                    │                     │
+│    client_tenant    │                    │                     │
+│    sent and routes  │                    │                     │
+│    to correct       │                    │                     │
+│    tenant           │                    │                     │
+└─────────────────────┘                    └─────────────────────┘
+```
 
 # ID Token Claims
 
@@ -81,37 +411,106 @@ The `session_expiry` claim is a JSON integer that represents the Unix timestamp 
 
 ## tenant
 
-The `tenant` claim is a JSON string that represents a tenant identifier and MAY have the value `personal`, `organization` or a stable, opaque to the RP, OP unique value for multi-tenant OPs. The `personal` value is reserved for when Accounts are managed by individuals. The `organization` value is reserved for Accounts managed by an organization.
+The `tenant` claim is a JSON string that represents an OP tenant identifier. This claim is OPTIONAL and MAY be included in ID Tokens.
+
+- **Single-tenant OPs**: Single-tenant OPs SHOULD omit the `tenant` claim.
+
+- **Multi-tenant OPs using a single issuer**: Multi-tenant OPs using a single issuer identifier SHOULD include the `tenant` claim to identify the OP tenant. The value MUST be a stable, opaque to the RP, OP unique identifier or a well known special value described below.
+
+- **Multi-tenant OPs using tenant-specific issuer identifiers**: Multi-tenant OPs using tenant-specific issuer identifiers SHOULD omit the `tenant` claim since the issuer identifier itself identifies the tenant.
+
+- **Special values**: The `tenant` claim MAY have the well-known value `personal` or `organization` instead of a unique identifier.
+  - `personal`: Indicates that accounts are managed by individuals rather than by a specific organizational tenant.
+  - `organization`: Indicates that accounts are managed by an organization.
+
+For multi-tenant OPs using tenant-specific issuer identifiers, if the `tenant` claim is present and does not match the tenant identified by the `iss` value, the RP SHOULD treat this as an error condition.
 
 ## aud_sub
 
-The `aud_sub` claim is an opaque JSON string that represents the identifier the RP has for the account. How the OP acquires the `aud_sub` and how the OP account and RP account linking is out of scope.
+The `aud_sub` claim is an opaque JSON string that represents the identifier the RP has for the account. This claim is OPTIONAL. How the OP acquires the `aud_sub` and how the OP account and RP account linking is established is out of scope of this specification.
 
+When the `aud_tenant` claim is present, the `aud_sub` claim represents the account identifier within the context of that specific RP tenant. See Section "aud_tenant" for uniqueness requirements.
+
+## aud_tenant
+
+The `aud_tenant` claim is a JSON string that represents an RP tenant identifier. This claim is OPTIONAL and is only included when the RP is multi-tenant and the OP knows the RP tenant identifier (see Section "RP Tenant Communication" for how the RP communicates its tenant identifier to the OP).
+
+When the RP provides the `client_tenant` authentication request parameter, the `aud_tenant` claim value MUST be the same value that the RP provided in that parameter. When the OP determines the RP tenant identifier through other means (e.g., `domain_hint`, `login_hint`, default tenant selection, or end-user selection), the `aud_tenant` claim value MUST be a valid RP tenant identifier for the client. The value is opaque to the OP (the OP does not need to understand its semantic meaning). The value MUST be a stable identifier that is unique within the context of the `client_id` used in the authentication request, ensuring that when multiple RP tenants share the same `client_id`, each tenant can be uniquely identified.
+
+When `aud_tenant` is present, the `aud_sub` claim represents the identifier the RP has for the account within the context of that specific RP tenant. The combination of `aud` + `aud_tenant` and `aud_sub` MUST be unique within the RP.
 
 # Authentication Request Parameters
 
-An Authentication request is defined in Section 3.1.2.1 of [OpenID Connect Core 1.0](#OpenID Connect Core 1.0).
+An Authentication request is defined in Section 3.1.2.1 of [OpenID Connect Core 1.0].
 
 Following are OPTIONAL parameters that may be included in an Authentication Request:
 
 ## domain_hint
 
-The `domain_hint` parameter provides a hint for the OP to determine which Tenant to present to the user to authenticate to.
+The `domain_hint` parameter provides a hint for the OP to determine which OP tenant to present to the user to authenticate to. This parameter is typically a domain name or email domain (e.g., `example.com`) that helps the OP identify the appropriate tenant. The `domain_hint` parameter is a user experience hint and is not guaranteed to uniquely identify a tenant.
 
 ## tenant
 
-The `tenant` identifier per the `tenant` claim for the OP Tenant that the RP would like the user to be authenticated to. Passing a `tenant` value of `personal` indicates the RP would like the user to use an account managed by user. Passing a `tenant` value of `organization` indicates the RP would like the user to use an account managed by an organization.
+The `tenant` parameter is the explicit OP tenant identifier value that corresponds to the `tenant` claim the RP would like included in the ID Token. This parameter takes precedence over `domain_hint` when both are present. 
 
+The `tenant` parameter value MUST match one of the following:
+- The value `personal` to indicate the RP would like the user to use an account managed by the user (personal account)
+- The value `organization` to indicate the RP would like the user to use an account managed by an organization (organizational account)
+- A stable, opaque OP tenant identifier value for multi-tenant OPs
+
+If the `tenant` parameter value does not match any OP tenant, the OP SHOULD return an `invalid_request` error or proceed with the authentication using the OP's default tenant selection logic. The specific behavior is implementation-dependent.
+
+## client_tenant
+
+The `client_tenant` parameter is an OPTIONAL parameter that the RP includes to communicate its RP tenant identifier to the OP. This parameter is used when the RP is multi-tenant and uses a shared `client_id` across multiple RP tenants (see Section "RP Tenancy" for details on multi-tenant RP models).
+
+The client MAY register allowed tenants using the `tenants` client registration parameter. When the `client_tenant` authentication request parameter is provided, the OP SHOULD validate that the `client_tenant` value corresponds to a valid RP tenant identifier that was registered for this client.
+
+The `client_tenant` parameter value MUST be a stable identifier that is unique within the context of the `client_id` used in the authentication request, ensuring that when multiple RP tenants share the same `client_id`, each tenant can be uniquely identified. The value is opaque to the OP (the OP does not need to understand its semantic meaning) and MUST be echoed back in the `aud_tenant` claim.
+
+If the `client_tenant` parameter is provided but the OP cannot determine the corresponding RP tenant (e.g., the value doesn't match any registered tenant identifier for the `client_id`), the OP SHOULD return an `invalid_request` error with an appropriate error description.
+
+If an RP is multi-tenant and uses a shared `client_id` but does not provide a `client_tenant` parameter, the OP MAY:
+- Attempt to resolve the RP tenant identifier using other available information (e.g., `domain_hint`, `login_hint`)
+- Select a default tenant for the client or fallback behavior (implementation-dependent)
+- Prompt the end-user to select a valid tenant for the client
+- Return an `invalid_request` error indicating that tenant identification is required
+
+If the OP successfully determines the RP tenant identifier through any of these means, it SHOULD include it in the `aud_tenant` claim of the ID Token.
+
+If the OP does not support RP tenant identification and receives a `client_tenant` parameter, the OP SHOULD ignore the parameter and MUST omit the `aud_tenant` claim from the ID Token.
+
+# Client Registration Parameters
+
+Client registration is defined in [OpenID Connect Dynamic Client Registration 1.0].
+
+Following are OPTIONAL client registration parameters that may be included during client registration:
+
+## tenants
+
+The `tenants` parameter is a JSON array of strings that represents RP tenant identifiers. This parameter is OPTIONAL and MAY be included during client registration.
+
+When the `client_tenant` authentication request parameter is provided, the OP MAY use the `tenants` client registration parameter to validate that the `client_tenant` value corresponds to a valid RP tenant identifier that was registered for this client. The OP can use this information to apply RP tenant-specific policies or to validate the authentication request.
+
+For example:
+
+```json
+{
+  "client_id": "rp-shared-abcde",
+  "redirect_uris": ["https://app.example.com/callback"],
+  "tenants": ["acme-corp-tenant-id", "widgets-inc-tenant-id"]
+}
+```
 
 # Login from a Third Party Parameters
 
-Initiating a login from a third party and a login initiation endpoint are defined in Section 4 of [OpenID Connect Core 1.0](#OpenID Connect Core 1.0). 
+Initiating a login from a third party and a login initiation endpoint are defined in Section 4 of [OpenID Connect Core 1.0].
 
 Following are OPTIONAL parameters that may be included in request to the login initiation endpoint:
 
 ## client_id
 
-The `client_id` value the RP should use when making the Authentication Request. This allows an multi-tenant application that hosts multiple tenants, each represented by a different `client_id`, to know which `client_id` to use.
+The `client_id` value the RP should use when making the Authentication Request. This allows a multi-tenant application that hosts multiple tenants, each represented by a different `client_id`, to know which `client_id` to use.
 
 ## domain_hint
 
@@ -121,12 +520,64 @@ The `domain_hint` value to be included in the Authentication Request.
 
 The `tenant` value to be included in the Authentication Request.
 
+## client_tenant
+
+The `client_tenant` value to be included in the Authentication Request.
 
 # Security Considerations
 
-*To be completed.*
+## OP Security Considerations
 
+### Tenant Isolation
 
+OPs MUST ensure strict isolation between tenants. An authenticated user from one OP tenant MUST NOT be able to obtain tokens containing a different tenant's identifier. The OP MUST validate that the `tenant` claim (see Section "ID Token Claims") in issued ID Tokens accurately reflects the tenant context in which the user authenticated.
+
+### Client Tenant Validation
+
+When the OP receives a `client_tenant` authentication request parameter (see Section "Authentication Request Parameters"), the OP SHOULD validate that the value corresponds to a registered RP tenant identifier for the given `client_id`. If the OP has registered the `tenants` client registration parameter (see Section "Client Registration Parameters") for the client, the OP SHOULD reject requests where `client_tenant` is not in the registered list.
+
+Failure to validate the `client_tenant` parameter could allow an attacker to request tokens for arbitrary RP tenants, potentially bypassing RP tenant-specific policies configured at the OP.
+
+### Subject Identifier Collision
+
+Multi-tenant OPs MUST ensure that subject identifiers are unambiguous across tenants to prevent account confusion where an RP incorrectly links accounts from different OP tenants.
+
+For multi-tenant OPs using a single issuer (see Section "OP Tenancy"), the OP MUST ensure that subject identifiers are unambiguous across tenants. If the same `sub` value could exist in multiple OP tenants, the OP MUST include the `tenant` claim (see Section "ID Token Claims") in the ID Token to enable RPs to correctly identify the account. The combination of `iss` + `tenant` + `sub` (for public subject identifiers) or `iss` + `tenant` + `client_id` + `sub` (for pairwise subject identifiers) MUST be unique across all tenants (see Section "OP Tenancy" for detailed requirements).
+
+For multi-tenant OPs using tenant-specific issuer identifiers (see Section "OP Tenancy"), the OP MUST ensure that the combination of `iss` + `sub` (for public subject identifiers) or `iss` + `client_id` + `sub` (for pairwise subject identifiers) is unique across all tenants. Since each tenant has a different issuer identifier, the OIDC Core requirement that `sub` is unique within `iss` already ensures tenant isolation. However, the OP MUST ensure uniqueness across all tenants, regardless of whether a client is shared across tenants or unique per tenant (see Section "OP Tenancy" for detailed requirements).
+
+### Token Injection Prevention
+
+OPs SHOULD implement measures to prevent token injection attacks where an attacker attempts to replay tokens across tenant boundaries. This includes ensuring that tokens issued for one tenant context cannot be used to authenticate to a different tenant.
+
+## RP Security Considerations
+
+### Tenant Claim Validation
+
+When an RP expects to receive the `tenant` claim (see Section "ID Token Claims") (e.g., when authenticating to a multi-tenant OP using a single issuer, as described in Section "OP Tenancy"), the RP MUST validate that the `tenant` claim is present in the ID Token. If the RP has prior knowledge of the expected tenant (e.g., from a previous authentication or configuration), the RP SHOULD validate that the received `tenant` claim matches the expected value.
+
+Failure to validate the `tenant` claim could result in:
+- Account confusion where users from different OP tenants are incorrectly linked
+- Privilege escalation if tenant-specific access controls are bypassed
+
+### aud_tenant Claim Validation
+
+When an RP sends the `client_tenant` authentication request parameter (see Section "Authentication Request Parameters"), the RP MUST validate that the returned `aud_tenant` claim (see Section "ID Token Claims") matches the value sent in the request. If the `aud_tenant` claim is missing or contains a different value, the RP MUST reject the ID Token.
+
+This validation prevents an attacker from obtaining a token intended for one RP tenant and using it to authenticate to a different RP tenant. See Section "RP Tenant Communication" for details on how the `client_tenant` parameter relates to the `aud_tenant` claim.
+
+### Account Identifier Uniqueness
+
+RPs MUST use the complete set of identifying claims when linking accounts:
+- For multi-tenant OPs using a single issuer (see Section "OP Tenancy"): `iss` + `tenant` (see Section "ID Token Claims") + `sub`
+- For multi-tenant OPs using tenant-specific issuers (see Section "OP Tenancy"): `iss` + `sub`
+- For multi-tenant RPs with shared `client_id` (see Section "RP Tenancy"): `aud` + `aud_tenant` (see Section "ID Token Claims") + `aud_sub` (see Section "ID Token Claims") (when present)
+
+Using only a subset of these claims (e.g., only `sub`) could result in incorrectly linking accounts from different tenants.
+
+### Cross-Tenant Request Forgery
+
+Multi-tenant RPs MUST ensure that authentication responses are processed in the correct tenant context. When using the `state` parameter or session context for tenant routing, the RP MUST validate that the response is processed by the same tenant that initiated the request. Failure to do so could allow an attacker to initiate authentication in one RP tenant and have the response processed in a different RP tenant.
 
 # Privacy Considerations
 
@@ -136,13 +587,14 @@ The `tenant` value to be included in the Authentication Request.
 
 *To be completed.*
 
-
 # References
 
 ## Normative References
 
-- **[RFC2119]** Bradner, S. “Key words for use in RFCs to Indicate Requirement Levels,” *RFC 2119*, March 1997.
-- **[OpenID Connect Core 1.0]** – “OpenID Connect Core 1.0 incorporating errata set 1,” available at <https://openid.net/specs/openid-connect-core-1_0.html>. 
+- **[RFC2119]** Bradner, S. "Key words for use in RFCs to Indicate Requirement Levels," *RFC 2119*, March 1997.
+- **[OpenID Connect Core 1.0]** – "OpenID Connect Core 1.0 incorporating errata set 2," available at <https://openid.net/specs/openid-connect-core-1_0.html>.
+- **[OpenID Connect Discovery 1.0]** – "OpenID Connect Discovery 1.0 incorporating errata set 2," available at <https://openid.net/specs/openid-connect-discovery-1_0.html>.
+- **[OpenID Connect Dynamic Client Registration 1.0]** – "OpenID Connect Dynamic Client Registration 1.0 incorporating errata set 2," available at <https://openid.net/specs/openid-connect-registration-1_0.html>. 
 
 ## Informative References
 
@@ -206,3 +658,13 @@ specification.
    -01
 
    * added `aud_sub` claim
+
+   -02
+
+   * added `aud_tenant` claim
+   * added `client_tenant` authentication request parameter
+   * added `tenants` client registration parameter
+   * added `client_tenant` to Login from a Third Party parameters
+   * added Tenancy Models section to describe OP and RP tenancy models and relationships
+   * added Security Considerations
+

--- a/openid-connect-enterprise-extensions-1_0.xml
+++ b/openid-connect-enterprise-extensions-1_0.xml
@@ -467,7 +467,7 @@ the use of <em>this fixed-width font</em>.</t>
 </tbody>
 </table>
 <ul spacing="compact">
-<li><strong>Discovery</strong>: If an OP publishes support for the <tt>tenant</tt> claim in the <tt>claims_supported</tt> metadata parameter (see [OpenID Connect Discovery 1.0]), then RPs SHOULD assume that the issuer is a multi-tenant OP using a single issuer identifier and SHOULD expect the <tt>tenant</tt> claim to be present in ID Tokens. The <tt>tenant</tt> claim value MUST be one of the allowed values for the corresponding OP model as specified in the table in <eref target="#tenant">Section "tenant"</eref>.</li>
+<li><strong>Discovery</strong>: If an OP publishes support for the <tt>tenant</tt> claim in the <tt>claims_supported</tt> metadata parameter (see [OpenID Connect Discovery 1.0]), then RPs SHOULD assume that the issuer is a multi-tenant OP using a single issuer identifier and SHOULD expect the <tt>tenant</tt> claim to be present in ID Tokens with a value of <tt>personal</tt> or a unique tenant identifier, as specified in <eref target="#tenant">Section "tenant"</eref>.</li>
 </ul>
 </section>
 

--- a/openid-connect-enterprise-extensions-1_0.xml
+++ b/openid-connect-enterprise-extensions-1_0.xml
@@ -761,6 +761,7 @@ specification.</t>
 <t>-02</t>
 
 <ul spacing="compact">
+<li>updated <tt>tenant</tt> claim rules</li>
 <li>added <tt>aud_tenant</tt> claim</li>
 <li>added <tt>client_tenant</tt> authentication request parameter</li>
 <li>added <tt>tenants</tt> client registration parameter</li>

--- a/openid-connect-enterprise-extensions-1_0.xml
+++ b/openid-connect-enterprise-extensions-1_0.xml
@@ -68,18 +68,22 @@ the use of <em>this fixed-width font</em>.</t>
 
 <section anchor="tenant"><name>tenant</name>
 <t>The <tt>tenant</tt> claim is a JSON string that represents an OP tenant identifier. This claim is OPTIONAL and MAY be included in ID Tokens.</t>
+<t>The following well-known values are defined for the <tt>tenant</tt> claim:</t>
 
 <ul>
-<li><t><strong>Single-tenant OPs</strong>: Single-tenant OPs SHOULD omit the <tt>tenant</tt> claim.</t>
+<li><tt>personal</tt>: Indicates that accounts are managed by individuals rather than by a specific organizational tenant.</li>
+<li><t><tt>organization</tt>: Indicates that accounts are managed by an organization.</t>
 </li>
-<li><t><strong>Multi-tenant OPs using a single issuer</strong>: Multi-tenant OPs using a single issuer identifier SHOULD include the <tt>tenant</tt> claim to identify the OP tenant. The value MUST be a stable, opaque to the RP, OP unique identifier or a well known special value described below.</t>
+<li><t><strong>Single-tenant OPs</strong>: Single-tenant OPs MAY include the <tt>tenant</tt> claim. If included, the value MUST be <tt>personal</tt> or <tt>organization</tt>.</t>
+</li>
+<li><t><strong>Multi-tenant OPs using a single issuer</strong>: Multi-tenant OPs using a single issuer identifier SHOULD include the <tt>tenant</tt> claim to identify the OP tenant. The value MUST be <tt>personal</tt> or a stable, opaque to the RP, OP unique tenant identifier.</t>
 
 <ul spacing="compact">
 <li>The combination of <tt>iss</tt>, <tt>tenant</tt>, and <tt>sub</tt> MUST be unique across all OP tenants.</li>
 <li>If the OP uses <tt>pairwise</tt> subject identifiers, the same user MAY have the same <tt>sub</tt> for the same <tt>client_id</tt> regardless of OP tenant. The <tt>tenant</tt> claim SHOULD be included in the uniqueness requirement (<tt>iss</tt> + <tt>tenant</tt> + <tt>sub</tt>) to disambiguate subjects across tenants.</li>
 <li>If the OP uses <tt>public</tt> subject identifiers, the <tt>sub</tt> value MUST be the same across all RPs/clients and all OP tenants. The <tt>tenant</tt> claim MUST be included in the uniqueness requirement (<tt>iss</tt> + <tt>tenant</tt> + <tt>sub</tt>) to disambiguate subjects across tenants.</li>
 </ul></li>
-<li><t><strong>Multi-tenant OPs using tenant-specific issuer identifiers</strong>: Multi-tenant OPs using tenant-specific issuer identifiers SHOULD omit the <tt>tenant</tt> claim since the issuer identifier itself identifies the tenant.</t>
+<li><t><strong>Multi-tenant OPs using tenant-specific issuer identifiers</strong>: Multi-tenant OPs using tenant-specific issuer identifiers SHOULD omit the <tt>tenant</tt> claim since the issuer identifier itself identifies the tenant. If the <tt>tenant</tt> claim is included, the value MUST be <tt>personal</tt> or <tt>organization</tt>.</t>
 
 <ul spacing="compact">
 <li>Each tenant issuer identifier MUST be a valid URL per [OpenID Connect Core 1.0] Section 2.</li>
@@ -87,19 +91,35 @@ the use of <em>this fixed-width font</em>.</t>
 <li>If the OP uses <tt>pairwise</tt> subject identifiers, the <tt>sub</tt> value MUST differ across <tt>client_id</tt> values within each tenant. The combination of <tt>iss</tt> + <tt>client_id</tt> + <tt>sub</tt> MUST be unique across all tenants.</li>
 <li>If the OP uses <tt>public</tt> subject identifiers, the <tt>sub</tt> value MUST be the same across all RPs/clients within each tenant. The <tt>sub</tt> value MAY be the same across tenants, but the combination of <tt>iss</tt> + <tt>sub</tt> MUST be unique across all tenants.</li>
 </ul></li>
-<li><t><strong>Special values</strong>: The <tt>tenant</tt> claim MAY have the well-known value <tt>personal</tt> or <tt>organization</tt> instead of a unique identifier.</t>
-
-<ul spacing="compact">
-<li><tt>personal</tt>: Indicates that accounts are managed by individuals rather than by a specific organizational tenant.</li>
-<li><tt>organization</tt>: Indicates that accounts are managed by an organization.</li>
-</ul></li>
+<li><t><strong>Discovery</strong>: If an OP publishes support for the <tt>tenant</tt> claim in the <tt>claims_supported</tt> metadata parameter (see [OpenID Connect Discovery 1.0]), then RPs SHOULD assume that the issuer is a multi-tenant OP using a single issuer identifier and SHOULD expect the <tt>tenant</tt> claim to be present in ID Tokens. The <tt>tenant</tt> claim value MUST be one of the allowed values for the corresponding OP model as specified in the table below.</t>
+</li>
 </ul>
-<t>For multi-tenant OPs using tenant-specific issuer identifiers, if the <tt>tenant</tt> claim is present and does not match the tenant identified by the <tt>iss</tt> value, the RP SHOULD treat this as an error condition.</t>
+<t>The following table summarizes the <tt>tenant</tt> claim rules by OP model:</t>
+<table>
+<thead>
+<tr>
+<th>OP Model</th>
+<th>Allowed Values</th>
+</tr>
+</thead>
 
-<ul spacing="compact">
-<li><strong>Discovery</strong>: If an OP publishes support for the <tt>tenant</tt> claim in the <tt>claims_supported</tt> metadata parameter (see [OpenID Connect Discovery 1.0]), then RPs SHOULD assume that the issuer supports multiple tenants and SHOULD expect the <tt>tenant</tt> claim to be present in ID Tokens.</li>
-</ul>
-</section>
+<tbody>
+<tr>
+<td>Single-tenant</td>
+<td><tt>personal</tt> or <tt>organization</tt></td>
+</tr>
+
+<tr>
+<td>Multi-tenant (single issuer)</td>
+<td><tt>personal</tt> or unique tenant identifier</td>
+</tr>
+
+<tr>
+<td>Multi-tenant (tenant-specific issuers)</td>
+<td><tt>personal</tt> or <tt>organization</tt></td>
+</tr>
+</tbody>
+</table></section>
 
 <section anchor="aud-sub"><name>aud_sub</name>
 <t>The <tt>aud_sub</tt> claim is an opaque JSON string that represents the identifier the RP has for the account. This claim is OPTIONAL. How the OP acquires the <tt>aud_sub</tt> and how the OP account and RP account linking is established is out of scope of this specification.</t>
@@ -108,7 +128,7 @@ the use of <em>this fixed-width font</em>.</t>
 </section>
 
 <section anchor="aud-tenant"><name>aud_tenant</name>
-<t>The <tt>aud_tenant</tt> claim is a JSON string that represents an RP tenant identifier. This claim is OPTIONAL and is only included when the RP is multi-tenant and the OP knows the RP tenant identifier (see Appendix A for how the RP communicates its tenant identifier to the OP).</t>
+<t>The <tt>aud_tenant</tt> claim is a JSON string that represents an RP tenant identifier. This claim is OPTIONAL and is only included when the RP is multi-tenant and the OP knows the RP tenant identifier (see <eref target="#enterprise-tenancy-models">Appendix A</eref> for how the RP communicates its tenant identifier to the OP).</t>
 <t>When the RP provides the <tt>client_tenant</tt> authentication request parameter, the <tt>aud_tenant</tt> claim value MUST be the same value that the RP provided in that parameter. When the OP determines the RP tenant identifier through other means (e.g., <tt>domain_hint</tt>, <tt>login_hint</tt>, default tenant selection, or end-user selection), the <tt>aud_tenant</tt> claim value MUST be a valid RP tenant identifier for the client. The value is opaque to the OP (the OP does not need to understand its semantic meaning). The value MUST be a stable identifier that is unique within the context of the <tt>client_id</tt> used in the authentication request, ensuring that when multiple RP tenants share the same <tt>client_id</tt>, each tenant can be uniquely identified.</t>
 <t>When <tt>aud_tenant</tt> is present, the <tt>aud_sub</tt> claim represents the identifier the RP has for the account within the context of that specific RP tenant. The combination of <tt>aud</tt> + <tt>aud_tenant</tt> and <tt>aud_sub</tt> MUST be unique within the RP.</t>
 </section>
@@ -124,15 +144,18 @@ the use of <em>this fixed-width font</em>.</t>
 
 <section anchor="tenant-1"><name>tenant</name>
 <t>The <tt>tenant</tt> parameter is the explicit OP tenant identifier value that corresponds to the <tt>tenant</tt> claim the RP would like included in the ID Token. This parameter takes precedence over <tt>domain_hint</tt> when both are present.</t>
-<t>The <tt>tenant</tt> parameter value MUST match one of the following:
-- The value <tt>personal</tt> to indicate the RP would like the user to use an account managed by the user (personal account)
-- The value <tt>organization</tt> to indicate the RP would like the user to use an account managed by an organization (organizational account)
-- A stable, opaque OP tenant identifier value for multi-tenant OPs</t>
+<t>The <tt>tenant</tt> parameter value MUST be one of the allowed values for the OP model as specified in the table in <eref target="#tenant">Section "tenant"</eref>:</t>
+
+<ul spacing="compact">
+<li>The value <tt>personal</tt> to indicate the RP would like the user to use a personal account (valid for all OP models)</li>
+<li>The value <tt>organization</tt> to indicate the RP would like the user to use an organizational account (valid for single-tenant OPs and multi-tenant OPs using tenant-specific issuers only)</li>
+<li>A stable, opaque OP tenant identifier (valid for multi-tenant OPs using a single issuer only)</li>
+</ul>
 <t>If the <tt>tenant</tt> parameter value does not match any OP tenant, the OP SHOULD return an <tt>invalid_request</tt> error or proceed with the authentication using the OP's default tenant selection logic. The specific behavior is implementation-dependent.</t>
 </section>
 
 <section anchor="client-tenant"><name>client_tenant</name>
-<t>The <tt>client_tenant</tt> parameter is an OPTIONAL parameter that the RP includes to communicate its RP tenant identifier to the OP. This parameter is used when the RP is multi-tenant and uses a shared <tt>client_id</tt> across multiple RP tenants (see Appendix A for details on multi-tenant RP models).</t>
+<t>The <tt>client_tenant</tt> parameter is an OPTIONAL parameter that the RP includes to communicate its RP tenant identifier to the OP. This parameter is used when the RP is multi-tenant and uses a shared <tt>client_id</tt> across multiple RP tenants (see <eref target="#enterprise-tenancy-models">Appendix A</eref> for details on multi-tenant RP models).</t>
 <t>The client MAY register allowed tenants using the <tt>tenants</tt> client registration parameter. When the <tt>client_tenant</tt> authentication request parameter is provided, the OP SHOULD validate that the <tt>client_tenant</tt> value corresponds to a valid RP tenant identifier that was registered for this client.</t>
 <t>The <tt>client_tenant</tt> parameter value MUST be a stable identifier that is unique within the context of the <tt>client_id</tt> used in the authentication request, ensuring that when multiple RP tenants share the same <tt>client_id</tt>, each tenant can be uniquely identified. The value is opaque to the OP (the OP does not need to understand its semantic meaning) and MUST be echoed back in the <tt>aud_tenant</tt> claim.</t>
 <t>The OP MUST treat the <tt>redirect_uri</tt> as opaque and MUST NOT attempt to identify an RP tenant from a specific URL endpoint or pattern.</t>
@@ -193,18 +216,18 @@ the use of <em>this fixed-width font</em>.</t>
 <section anchor="op-security-considerations"><name>OP Security Considerations</name>
 
 <section anchor="tenant-isolation"><name>Tenant Isolation</name>
-<t>OPs MUST ensure strict isolation between tenants. An authenticated user from one OP tenant MUST NOT be able to obtain tokens containing a different tenant's identifier. The OP MUST validate that the <tt>tenant</tt> claim (see Section &quot;ID Token Claims&quot;) in issued ID Tokens accurately reflects the tenant context in which the user authenticated.</t>
+<t>OPs MUST ensure strict isolation between tenants. An authenticated user from one OP tenant MUST NOT be able to obtain tokens containing a different tenant's identifier. The OP MUST validate that the <tt>tenant</tt> claim (see <eref target="#id-token-claims">Section "ID Token Claims"</eref>) in issued ID Tokens accurately reflects the tenant context in which the user authenticated.</t>
 </section>
 
 <section anchor="client-tenant-validation"><name>Client Tenant Validation</name>
-<t>When the OP receives a <tt>client_tenant</tt> authentication request parameter (see Section &quot;Authentication Request Parameters&quot;), the OP SHOULD validate that the value corresponds to a registered RP tenant identifier for the given <tt>client_id</tt>. If the OP has registered the <tt>tenants</tt> client registration parameter (see Section &quot;Client Registration Parameters&quot;) for the client, the OP SHOULD reject requests where <tt>client_tenant</tt> is not in the registered list.</t>
+<t>When the OP receives a <tt>client_tenant</tt> authentication request parameter (see <eref target="#authentication-request-parameters">Section "Authentication Request Parameters"</eref>), the OP SHOULD validate that the value corresponds to a registered RP tenant identifier for the given <tt>client_id</tt>. If the OP has registered the <tt>tenants</tt> client registration parameter (see <eref target="#client-registration-parameters">Section "Client Registration Parameters"</eref>) for the client, the OP SHOULD reject requests where <tt>client_tenant</tt> is not in the registered list.</t>
 <t>Failure to validate the <tt>client_tenant</tt> parameter could allow an attacker to request tokens for arbitrary RP tenants, potentially bypassing RP tenant-specific policies configured at the OP.</t>
 </section>
 
 <section anchor="subject-identifier-collision"><name>Subject Identifier Collision</name>
 <t>Multi-tenant OPs MUST ensure that subject identifiers are unambiguous across tenants to prevent account confusion where an RP incorrectly links accounts from different OP tenants.</t>
-<t>For multi-tenant OPs using a single issuer (see Appendix A), the OP MUST ensure that subject identifiers are unambiguous across tenants. If the same <tt>sub</tt> value could exist in multiple OP tenants, the OP MUST include the <tt>tenant</tt> claim (see Section &quot;ID Token Claims&quot;) in the ID Token to enable RPs to correctly identify the account. The combination of <tt>iss</tt> + <tt>tenant</tt> + <tt>sub</tt> (for public subject identifiers) or <tt>iss</tt> + <tt>tenant</tt> + <tt>client_id</tt> + <tt>sub</tt> (for pairwise subject identifiers) MUST be unique across all tenants (see Appendix A for detailed requirements).</t>
-<t>For multi-tenant OPs using tenant-specific issuer identifiers (see Appendix A), the OP MUST ensure that the combination of <tt>iss</tt> + <tt>sub</tt> (for public subject identifiers) or <tt>iss</tt> + <tt>client_id</tt> + <tt>sub</tt> (for pairwise subject identifiers) is unique across all tenants. Since each tenant has a different issuer identifier, the OIDC Core requirement that <tt>sub</tt> is unique within <tt>iss</tt> already ensures tenant isolation. However, the OP MUST ensure uniqueness across all tenants, regardless of whether a client is shared across tenants or unique per tenant (see Appendix A for detailed requirements).</t>
+<t>For multi-tenant OPs using a single issuer (see <eref target="#enterprise-tenancy-models">Appendix A</eref>), the OP MUST ensure that subject identifiers are unambiguous across tenants. If the same <tt>sub</tt> value could exist in multiple OP tenants, the OP MUST include the <tt>tenant</tt> claim (see <eref target="#id-token-claims">Section "ID Token Claims"</eref>) in the ID Token to enable RPs to correctly identify the account. The combination of <tt>iss</tt> + <tt>tenant</tt> + <tt>sub</tt> (for public subject identifiers) or <tt>iss</tt> + <tt>tenant</tt> + <tt>client_id</tt> + <tt>sub</tt> (for pairwise subject identifiers) MUST be unique across all tenants (see <eref target="#enterprise-tenancy-models">Appendix A</eref> for detailed requirements).</t>
+<t>For multi-tenant OPs using tenant-specific issuer identifiers (see <eref target="#enterprise-tenancy-models">Appendix A</eref>), the OP MUST ensure that the combination of <tt>iss</tt> + <tt>sub</tt> (for public subject identifiers) or <tt>iss</tt> + <tt>client_id</tt> + <tt>sub</tt> (for pairwise subject identifiers) is unique across all tenants. Since each tenant has a different issuer identifier, the OIDC Core requirement that <tt>sub</tt> is unique within <tt>iss</tt> already ensures tenant isolation. However, the OP MUST ensure uniqueness across all tenants, regardless of whether a client is shared across tenants or unique per tenant (see <eref target="#enterprise-tenancy-models">Appendix A</eref> for detailed requirements).</t>
 </section>
 
 <section anchor="token-injection-prevention"><name>Token Injection Prevention</name>
@@ -215,22 +238,22 @@ the use of <em>this fixed-width font</em>.</t>
 <section anchor="rp-security-considerations"><name>RP Security Considerations</name>
 
 <section anchor="tenant-claim-validation"><name>Tenant Claim Validation</name>
-<t>When an RP expects to receive the <tt>tenant</tt> claim (see Section &quot;ID Token Claims&quot;) (e.g., when authenticating to a multi-tenant OP using a single issuer, as described in Appendix A), the RP MUST validate that the <tt>tenant</tt> claim is present in the ID Token. If the RP has prior knowledge of the expected tenant (e.g., from a previous authentication or configuration), the RP SHOULD validate that the received <tt>tenant</tt> claim matches the expected value.</t>
+<t>When an RP expects to receive the <tt>tenant</tt> claim (see <eref target="#id-token-claims">Section "ID Token Claims"</eref>) (e.g., when authenticating to a multi-tenant OP using a single issuer, as described in <eref target="#enterprise-tenancy-models">Appendix A</eref>), the RP MUST validate that the <tt>tenant</tt> claim is present in the ID Token. If the RP has prior knowledge of the expected tenant (e.g., from a previous authentication or configuration), the RP SHOULD validate that the received <tt>tenant</tt> claim matches the expected value.</t>
 <t>Failure to validate the <tt>tenant</tt> claim could result in:
 - Account confusion where users from different OP tenants are incorrectly linked
 - Privilege escalation if tenant-specific access controls are bypassed</t>
 </section>
 
 <section anchor="aud-tenant-claim-validation"><name>aud_tenant Claim Validation</name>
-<t>When an RP sends the <tt>client_tenant</tt> authentication request parameter (see Section &quot;Authentication Request Parameters&quot;), the RP MUST validate that the returned <tt>aud_tenant</tt> claim (see Section &quot;ID Token Claims&quot;) matches the value sent in the request. If the <tt>aud_tenant</tt> claim is missing or contains a different value, the RP MUST reject the ID Token.</t>
-<t>This validation prevents an attacker from obtaining a token intended for one RP tenant and using it to authenticate to a different RP tenant. See Appendix A for details on how the <tt>client_tenant</tt> parameter relates to the <tt>aud_tenant</tt> claim.</t>
+<t>When an RP sends the <tt>client_tenant</tt> authentication request parameter (see <eref target="#authentication-request-parameters">Section "Authentication Request Parameters"</eref>), the RP MUST validate that the returned <tt>aud_tenant</tt> claim (see <eref target="#id-token-claims">Section "ID Token Claims"</eref>) matches the value sent in the request. If the <tt>aud_tenant</tt> claim is missing or contains a different value, the RP MUST reject the ID Token.</t>
+<t>This validation prevents an attacker from obtaining a token intended for one RP tenant and using it to authenticate to a different RP tenant. See <eref target="#enterprise-tenancy-models">Appendix A</eref> for details on how the <tt>client_tenant</tt> parameter relates to the <tt>aud_tenant</tt> claim.</t>
 </section>
 
 <section anchor="account-identifier-uniqueness"><name>Account Identifier Uniqueness</name>
 <t>RPs MUST use the complete set of identifying claims when linking accounts:
-- For multi-tenant OPs using a single issuer (see Appendix A): <tt>iss</tt> + <tt>tenant</tt> (see Section &quot;ID Token Claims&quot;) + <tt>sub</tt>
-- For multi-tenant OPs using tenant-specific issuers (see Appendix A): <tt>iss</tt> + <tt>sub</tt>
-- For multi-tenant RPs with shared <tt>client_id</tt> (see Appendix A): <tt>aud</tt> + <tt>aud_tenant</tt> (see Section &quot;ID Token Claims&quot;) + <tt>aud_sub</tt> (see Section &quot;ID Token Claims&quot;) (when present)</t>
+- For multi-tenant OPs using a single issuer (see <eref target="#enterprise-tenancy-models">Appendix A</eref>): <tt>iss</tt> + <tt>tenant</tt> (see <eref target="#id-token-claims">Section "ID Token Claims"</eref>) + <tt>sub</tt>
+- For multi-tenant OPs using tenant-specific issuers (see <eref target="#enterprise-tenancy-models">Appendix A</eref>): <tt>iss</tt> + <tt>sub</tt>
+- For multi-tenant RPs with shared <tt>client_id</tt> (see <eref target="#enterprise-tenancy-models">Appendix A</eref>): <tt>aud</tt> + <tt>aud_tenant</tt> (see <eref target="#id-token-claims">Section "ID Token Claims"</eref>) + <tt>aud_sub</tt> (see <eref target="#id-token-claims">Section "ID Token Claims"</eref>) (when present)</t>
 <t>Using only a subset of these claims (e.g., only <tt>sub</tt>) could result in incorrectly linking accounts from different tenants.</t>
 </section>
 
@@ -342,7 +365,7 @@ the use of <em>this fixed-width font</em>.</t>
 <li><t><strong>Multi-tenant OP</strong>: The OP has multiple tenants. Multi-tenant OPs may use a single issuer identifier for all tenants, or tenant-specific issuer identifiers:</t>
 
 <ul>
-<li><t><strong>Single issuer for all tenants</strong>: The OP uses one issuer identifier for all tenants, and the <tt>tenant</tt> claim (see Section &quot;ID Token Claims&quot;) distinguishes between tenants.</t>
+<li><t><strong>Single issuer for all tenants</strong>: The OP uses one issuer identifier for all tenants, and the <tt>tenant</tt> claim (see <eref target="#id-token-claims">Section "ID Token Claims"</eref>) distinguishes between tenants.</t>
 
 <ul>
 <li><t><strong>Issuer Configuration</strong>: All tenants share the same issuer identifier (<tt>iss</tt>), OP metadata endpoint, and signing keys.</t>
@@ -431,7 +454,7 @@ the use of <em>this fixed-width font</em>.</t>
 <td>Single <tt>iss</tt> shared across tenants, single metadata endpoint, single signing keys</td>
 <td><tt>public</tt>: <tt>iss</tt> + <tt>tenant</tt> + <tt>sub</tt> unique<br />
 <tt>pairwise</tt>: <tt>iss</tt> + <tt>tenant</tt> + <tt>client_id</tt> + <tt>sub</tt> unique</td>
-<td><tt>tenant</tt> claim in ID Token (see Section &quot;ID Token Claims&quot;)</td>
+<td><tt>tenant</tt> claim in ID Token (see <eref target="#id-token-claims">Section "ID Token Claims"</eref>)</td>
 </tr>
 
 <tr>
@@ -444,7 +467,7 @@ the use of <em>this fixed-width font</em>.</t>
 </tbody>
 </table>
 <ul spacing="compact">
-<li><strong>Discovery</strong>: If an OP publishes support for the <tt>tenant</tt> claim in the <tt>claims_supported</tt> metadata parameter (see [OpenID Connect Discovery 1.0]), then RPs SHOULD assume that the issuer supports multiple tenants and SHOULD expect the <tt>tenant</tt> claim to be present in ID Tokens.</li>
+<li><strong>Discovery</strong>: If an OP publishes support for the <tt>tenant</tt> claim in the <tt>claims_supported</tt> metadata parameter (see [OpenID Connect Discovery 1.0]), then RPs SHOULD assume that the issuer is a multi-tenant OP using a single issuer identifier and SHOULD expect the <tt>tenant</tt> claim to be present in ID Tokens. The <tt>tenant</tt> claim value MUST be one of the allowed values for the corresponding OP model as specified in the table in <eref target="#tenant">Section "tenant"</eref>.</li>
 </ul>
 </section>
 
@@ -453,9 +476,9 @@ the use of <em>this fixed-width font</em>.</t>
 <t>The following applies only to multi-tenant OPs that use a single issuer for all tenants. For such OPs, the RP MAY specify which OP tenant it wants the user to authenticate to using one of the following mechanisms:</t>
 
 <ul>
-<li><t><strong><tt>tenant</tt> parameter</strong>: The RP includes the <tt>tenant</tt> parameter in the authentication request with the OP tenant identifier value (e.g., <tt>tenant=acme-corp</tt>). When the OP receives this parameter, it SHOULD include the <tt>tenant</tt> claim in the ID Token with the same value. This is RECOMMENDED for RPs that know which <tt>tenant</tt> to make an authentication request to. See Section &quot;Authentication Request Parameters&quot; for details.</t>
+<li><t><strong><tt>tenant</tt> parameter</strong>: The RP includes the <tt>tenant</tt> parameter in the authentication request with the OP tenant identifier value (e.g., <tt>tenant=acme-corp</tt>). When the OP receives this parameter, it SHOULD include the <tt>tenant</tt> claim in the ID Token with the same value. This is RECOMMENDED for RPs that know which <tt>tenant</tt> to make an authentication request to. See <eref target="#authentication-request-parameters">Section "Authentication Request Parameters"</eref> for details.</t>
 </li>
-<li><t><strong><tt>domain_hint</tt> parameter</strong>: The RP includes the <tt>domain_hint</tt> parameter with a domain name or email domain (e.g., <tt>example.com</tt>) that helps the OP identify the appropriate tenant. This is a user experience hint and is not guaranteed to uniquely identify a tenant. When both <tt>tenant</tt> and <tt>domain_hint</tt> are present, the <tt>tenant</tt> parameter takes precedence. If the OP cannot uniquely identify the tenant from <tt>domain_hint</tt> alone, the OP's tenant selection behavior is implementation-dependent. See Section &quot;Authentication Request Parameters&quot; for details.</t>
+<li><t><strong><tt>domain_hint</tt> parameter</strong>: The RP includes the <tt>domain_hint</tt> parameter with a domain name or email domain (e.g., <tt>example.com</tt>) that helps the OP identify the appropriate tenant. This is a user experience hint and is not guaranteed to uniquely identify a tenant. When both <tt>tenant</tt> and <tt>domain_hint</tt> are present, the <tt>tenant</tt> parameter takes precedence. If the OP cannot uniquely identify the tenant from <tt>domain_hint</tt> alone, the OP's tenant selection behavior is implementation-dependent. See <eref target="#authentication-request-parameters">Section "Authentication Request Parameters"</eref> for details.</t>
 </li>
 </ul>
 <t>When the OP tenant is not specified by the RP (neither <tt>tenant</tt> nor <tt>domain_hint</tt> is provided, or <tt>domain_hint</tt> does not uniquely identify a tenant), the OP MAY:
@@ -561,7 +584,7 @@ the use of <em>this fixed-width font</em>.</t>
 <li><t><strong>Shared Client for all Tenants</strong>: Multiple RP tenants share a single <tt>client_id</tt> registered with the OP.</t>
 
 <ul spacing="compact">
-<li><strong>Registration</strong>: All RP tenants share a single <tt>client_id</tt> registered with the OP. The RP MAY register the <tt>tenants</tt> client registration parameter (see Section &quot;Client Registration Parameters&quot;) as a JSON array of strings containing the RP tenant identifiers.</li>
+<li><strong>Registration</strong>: All RP tenants share a single <tt>client_id</tt> registered with the OP. The RP MAY register the <tt>tenants</tt> client registration parameter (see <eref target="#client-registration-parameters">Section "Client Registration Parameters"</eref>) as a JSON array of strings containing the RP tenant identifiers.</li>
 <li><strong>Account Identifier Uniqueness</strong>: When both <tt>aud_tenant</tt> and <tt>aud_sub</tt> are present, their combination MUST be unique for a given <tt>aud</tt> (client identifier) within the RP. This ensures that account identifiers are unambiguous within the context of the RP, even when the same <tt>aud_sub</tt> value might exist in different RP tenants.</li>
 </ul></li>
 </ul>
@@ -620,7 +643,7 @@ the use of <em>this fixed-width font</em>.</t>
 <td>Multi-tenant RP (shared client)</td>
 <td>Single <tt>client_id</tt> shared across tenants, <tt>tenants</tt> parameter MAY be registered</td>
 <td><tt>aud_tenant</tt> + <tt>aud_sub</tt> unique within <tt>aud</tt></td>
-<td><tt>aud</tt> + <tt>aud_tenant</tt> claim in ID Token (see Section &quot;ID Token Claims&quot;)</td>
+<td><tt>aud</tt> + <tt>aud_tenant</tt> claim in ID Token (see <eref target="#id-token-claims">Section "ID Token Claims"</eref>)</td>
 </tr>
 </tbody>
 </table>
@@ -630,11 +653,11 @@ the use of <em>this fixed-width font</em>.</t>
 </section>
 
 <section anchor="rp-tenant-communication"><name>RP Tenant Communication</name>
-<t>When an RP is multi-tenant and uses a shared <tt>client_id</tt>, the RP MAY communicate its tenant identifier to the OP, but is not required to do so. If the OP knows the RP tenant identifier, it SHOULD include it in the <tt>aud_tenant</tt> claim of the ID Token (see Section &quot;ID Token Claims&quot;).</t>
+<t>When an RP is multi-tenant and uses a shared <tt>client_id</tt>, the RP MAY communicate its tenant identifier to the OP, but is not required to do so. If the OP knows the RP tenant identifier, it SHOULD include it in the <tt>aud_tenant</tt> claim of the ID Token (see <eref target="#id-token-claims">Section "ID Token Claims"</eref>).</t>
 <t>The RP can communicate its tenant identifier using one of the following mechanisms:</t>
 
 <ul>
-<li><t><strong><tt>client_tenant</tt> authentication request parameter</strong> (RECOMMENDED): The RP includes the <tt>client_tenant</tt> parameter in the authentication request with its tenant identifier value. This is explicit and unambiguous, allowing the OP to include the <tt>aud_tenant</tt> claim in the ID Token and apply RP tenant-specific policies (e.g., access control, consent requirements, authentication methods). When present, the OP MUST echo this value back in the <tt>aud_tenant</tt> claim. See Section &quot;Authentication Request Parameters&quot; for details.</t>
+<li><t><strong><tt>client_tenant</tt> authentication request parameter</strong> (RECOMMENDED): The RP includes the <tt>client_tenant</tt> parameter in the authentication request with its tenant identifier value. This is explicit and unambiguous, allowing the OP to include the <tt>aud_tenant</tt> claim in the ID Token and apply RP tenant-specific policies (e.g., access control, consent requirements, authentication methods). When present, the OP MUST echo this value back in the <tt>aud_tenant</tt> claim. See <eref target="#authentication-request-parameters">Section "Authentication Request Parameters"</eref> for details.</t>
 </li>
 <li><t><strong><tt>state</tt> parameter or session context</strong>: RPs may include tenant identification information in the opaque <tt>state</tt> parameter of the OpenID Connect Authentication Request, or maintain tenant context via cookies or other session mechanisms. When the RP uses only this mechanism, the OP does not have access to the tenant identifier and MUST omit the <tt>aud_tenant</tt> claim from the ID Token. The OP cannot apply RP tenant-specific policies, and the RP MUST use implementation-specific mechanisms (such as parsing the <tt>state</tt> parameter or session context) to determine the tenant for routing the authentication response. This pattern is commonly used in practice.</t>
 </li>

--- a/openid-connect-enterprise-extensions-1_0.xml
+++ b/openid-connect-enterprise-extensions-1_0.xml
@@ -1,0 +1,752 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- name="GENERATOR" content="github.com/mmarkdown/mmark Mmark Markdown Processor - mmark.miek.nl" -->
+<rfc version="3" ipr="none" docName="openid-connect-enterprise-extensions-1_0" submissionType="IETF" category="std" xml:lang="en" xmlns:xi="http://www.w3.org/2001/XInclude" indexInclude="true">
+
+<front>
+<title abbrev="openid-connect-enterprise-extensions">OpenID Connect Enterprise Extensions 1.0 - draft 02</title><seriesInfo value="openid-connect-enterprise-extensions-1_0" status="standard" name="Internet-Draft"></seriesInfo>
+<author initials="D." surname="Hardt" fullname="Dick Hardt"><organization>Hellō</organization><address><postal><street></street>
+</postal><email>dick.hardt@gmail.com</email>
+</address></author><author initials="K." surname="McGuinness" fullname="Karl McGuinness"><organization>Independent</organization><address><postal><street></street>
+</postal><email>me@karlmcguinness.com</email>
+</address></author><date/>
+<area>Internet</area>
+<workgroup>OpenID Connect</workgroup>
+<keyword>security</keyword>
+<keyword>openid</keyword>
+<keyword>enterprise</keyword>
+
+<abstract>
+<t>OpenID Connect 1.0 has become a popular choice for single sign-on in enterprise use cases. To improve interoperability, OpenID Connect Enterprise Extensions specifies a number of common or desirable extensions to OpenID Connect.</t>
+</abstract>
+
+</front>
+
+<middle>
+
+<section anchor="introduction"><name>Introduction</name>
+<t>OpenID Connect 1.0 is a widely adopted identity protocol that enables client applications, known as relying parties (RPs), to verify the identity of end-users based on authentication performed by a trusted service, the OpenID Provider (OP).</t>
+<t>Initial adoption of OpenID Connect was by sites providing personal identity to applications. OpenID Connect has become a popular choice in enterprise use cases, and implementors have defined their own extensions for use cases that were not addressed in the original specification.</t>
+<t>To improve interoperability between systems, OpenID Connect Enterprise Extensions specifies optional claims that may be included in an ID Token, optional parameters that may be included in an authentication request, optional client registration parameters, and optional parameters that may be included when initiating login from a third party.</t>
+<t>Enterprise deployments of OpenID Connect often involve multi-tenancy on both sides of the protocol. An OpenID Provider (OP) may serve multiple organizations, each with their own users and policies. Similarly, a Relying Party (RP) may be a SaaS application serving multiple customer organizations, each requiring isolation of their users and data.</t>
+<t>This specification addresses three key challenges in multi-tenant deployments:</t>
+<t><strong>OP Tenant Identification</strong>: When an OP serves multiple tenants using a single issuer identifier, the standard <tt>iss</tt> and <tt>sub</tt> claims are insufficient to uniquely identify a user across tenants. This specification defines the <tt>tenant</tt> claim to disambiguate users and the <tt>tenant</tt> and <tt>domain_hint</tt> authentication request parameters to allow RPs to specify which OP tenant to authenticate against.</t>
+<t><strong>RP Tenant Identification</strong>: When an RP serves multiple tenants using a shared client registration, the OP has no standard way to know which RP tenant initiated the authentication request. This specification defines the <tt>client_tenant</tt> authentication request parameter and the <tt>aud_tenant</tt> ID Token claim to enable RPs to communicate their tenant context to the OP, allowing the OP to apply tenant-specific policies and echo the tenant identifier back in the token.</t>
+<t><strong>Account Linking</strong>: When an OP maintains account linkages to RP accounts, the standard claims do not provide a mechanism to communicate the RP's account identifier. This specification defines the <tt>aud_sub</tt> claim to allow the OP to include the RP's account identifier in the ID Token, and the <tt>aud_tenant</tt> claim to scope that identifier to a specific RP tenant when applicable.</t>
+
+<section anchor="requirements-notation-and-conventions"><name>Requirements Notation and Conventions</name>
+<t>The key words &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;,
+&quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this
+document are to be interpreted as described in <eref target="#RFC2119">RFC2119</eref>.</t>
+<t>In the .txt version of this specification,
+values are quoted to indicate that they are to be taken literally.
+When using these values in protocol messages,
+the quotes MUST NOT be used as part of the value.
+In the HTML version of this specification,
+values to be taken literally are indicated by
+the use of <em>this fixed-width font</em>.</t>
+</section>
+
+<section anchor="terminology"><name>Terminology</name>
+<t>This specification defines the following terms:</t>
+
+<ul>
+<li><t><strong>Account</strong>: A set of claims about a user.</t>
+</li>
+<li><t><strong>Tenant</strong>: A logically isolated entity that represents a distinct organizational or administrative boundary. A tenant may contain accounts managed by individuals or by an organization. Both an OpenID Provider (OP) and a Relying Party (RP) may have a single tenant or multiple tenants. When referring to a tenant within an OP, it is called an &quot;OP tenant&quot;. When referring to a tenant within an RP, it is called an &quot;RP tenant&quot;.</t>
+</li>
+</ul>
+</section>
+</section>
+
+<section anchor="id-token-claims"><name>ID Token Claims</name>
+<t>An ID Token is defined in Section 2 of <eref target="#OpenID Connect Core 1.0">OpenID Connect Core 1.0</eref>.</t>
+<t>Following are OPTIONAL claims that may be included in an ID Token:</t>
+
+<section anchor="session-expiry"><name>session_expiry</name>
+<t>The <tt>session_expiry</tt> claim is a JSON integer that represents the Unix timestamp (seconds since epoch) indicating when a session created from the ID Token MUST expire.</t>
+</section>
+
+<section anchor="tenant"><name>tenant</name>
+<t>The <tt>tenant</tt> claim is a JSON string that represents an OP tenant identifier. This claim is OPTIONAL and MAY be included in ID Tokens.</t>
+
+<ul>
+<li><t><strong>Single-tenant OPs</strong>: Single-tenant OPs SHOULD omit the <tt>tenant</tt> claim.</t>
+</li>
+<li><t><strong>Multi-tenant OPs using a single issuer</strong>: Multi-tenant OPs using a single issuer identifier SHOULD include the <tt>tenant</tt> claim to identify the OP tenant. The value MUST be a stable, opaque to the RP, OP unique identifier or a well known special value described below.</t>
+
+<ul spacing="compact">
+<li>The combination of <tt>iss</tt>, <tt>tenant</tt>, and <tt>sub</tt> MUST be unique across all OP tenants.</li>
+<li>If the OP uses <tt>pairwise</tt> subject identifiers, the same user MAY have the same <tt>sub</tt> for the same <tt>client_id</tt> regardless of OP tenant. The <tt>tenant</tt> claim SHOULD be included in the uniqueness requirement (<tt>iss</tt> + <tt>tenant</tt> + <tt>sub</tt>) to disambiguate subjects across tenants.</li>
+<li>If the OP uses <tt>public</tt> subject identifiers, the <tt>sub</tt> value MUST be the same across all RPs/clients and all OP tenants. The <tt>tenant</tt> claim MUST be included in the uniqueness requirement (<tt>iss</tt> + <tt>tenant</tt> + <tt>sub</tt>) to disambiguate subjects across tenants.</li>
+</ul></li>
+<li><t><strong>Multi-tenant OPs using tenant-specific issuer identifiers</strong>: Multi-tenant OPs using tenant-specific issuer identifiers SHOULD omit the <tt>tenant</tt> claim since the issuer identifier itself identifies the tenant.</t>
+
+<ul spacing="compact">
+<li>Each tenant issuer identifier MUST be a valid URL per [OpenID Connect Core 1.0] Section 2.</li>
+<li>The combination of <tt>iss</tt> and <tt>sub</tt> MUST be unique per tenant.</li>
+<li>If the OP uses <tt>pairwise</tt> subject identifiers, the <tt>sub</tt> value MUST differ across <tt>client_id</tt> values within each tenant. The combination of <tt>iss</tt> + <tt>client_id</tt> + <tt>sub</tt> MUST be unique across all tenants.</li>
+<li>If the OP uses <tt>public</tt> subject identifiers, the <tt>sub</tt> value MUST be the same across all RPs/clients within each tenant. The <tt>sub</tt> value MAY be the same across tenants, but the combination of <tt>iss</tt> + <tt>sub</tt> MUST be unique across all tenants.</li>
+</ul></li>
+<li><t><strong>Special values</strong>: The <tt>tenant</tt> claim MAY have the well-known value <tt>personal</tt> or <tt>organization</tt> instead of a unique identifier.</t>
+
+<ul spacing="compact">
+<li><tt>personal</tt>: Indicates that accounts are managed by individuals rather than by a specific organizational tenant.</li>
+<li><tt>organization</tt>: Indicates that accounts are managed by an organization.</li>
+</ul></li>
+</ul>
+<t>For multi-tenant OPs using tenant-specific issuer identifiers, if the <tt>tenant</tt> claim is present and does not match the tenant identified by the <tt>iss</tt> value, the RP SHOULD treat this as an error condition.</t>
+
+<ul spacing="compact">
+<li><strong>Discovery</strong>: If an OP publishes support for the <tt>tenant</tt> claim in the <tt>claims_supported</tt> metadata parameter (see [OpenID Connect Discovery 1.0]), then RPs SHOULD assume that the issuer supports multiple tenants and SHOULD expect the <tt>tenant</tt> claim to be present in ID Tokens.</li>
+</ul>
+</section>
+
+<section anchor="aud-sub"><name>aud_sub</name>
+<t>The <tt>aud_sub</tt> claim is an opaque JSON string that represents the identifier the RP has for the account. This claim is OPTIONAL. How the OP acquires the <tt>aud_sub</tt> and how the OP account and RP account linking is established is out of scope of this specification.</t>
+<t>The <tt>aud_sub</tt> value MUST be unique within the context of the <tt>client_id</tt>.</t>
+<t>When the <tt>aud_tenant</tt> claim is present, the <tt>aud_sub</tt> claim represents the account identifier within the context of that specific RP tenant. See Section &quot;aud_tenant&quot; for uniqueness requirements.</t>
+</section>
+
+<section anchor="aud-tenant"><name>aud_tenant</name>
+<t>The <tt>aud_tenant</tt> claim is a JSON string that represents an RP tenant identifier. This claim is OPTIONAL and is only included when the RP is multi-tenant and the OP knows the RP tenant identifier (see Appendix A for how the RP communicates its tenant identifier to the OP).</t>
+<t>When the RP provides the <tt>client_tenant</tt> authentication request parameter, the <tt>aud_tenant</tt> claim value MUST be the same value that the RP provided in that parameter. When the OP determines the RP tenant identifier through other means (e.g., <tt>domain_hint</tt>, <tt>login_hint</tt>, default tenant selection, or end-user selection), the <tt>aud_tenant</tt> claim value MUST be a valid RP tenant identifier for the client. The value is opaque to the OP (the OP does not need to understand its semantic meaning). The value MUST be a stable identifier that is unique within the context of the <tt>client_id</tt> used in the authentication request, ensuring that when multiple RP tenants share the same <tt>client_id</tt>, each tenant can be uniquely identified.</t>
+<t>When <tt>aud_tenant</tt> is present, the <tt>aud_sub</tt> claim represents the identifier the RP has for the account within the context of that specific RP tenant. The combination of <tt>aud</tt> + <tt>aud_tenant</tt> and <tt>aud_sub</tt> MUST be unique within the RP.</t>
+</section>
+</section>
+
+<section anchor="authentication-request-parameters"><name>Authentication Request Parameters</name>
+<t>An Authentication request is defined in Section 3.1.2.1 of [OpenID Connect Core 1.0].</t>
+<t>Following are OPTIONAL parameters that may be included in an Authentication Request:</t>
+
+<section anchor="domain-hint"><name>domain_hint</name>
+<t>The <tt>domain_hint</tt> parameter provides a hint for the OP to determine which OP tenant to present to the user to authenticate to. This parameter is typically a domain name or email domain (e.g., <tt>example.com</tt>) that helps the OP identify the appropriate tenant. The <tt>domain_hint</tt> parameter is a user experience hint and is not guaranteed to uniquely identify a tenant.</t>
+</section>
+
+<section anchor="tenant-1"><name>tenant</name>
+<t>The <tt>tenant</tt> parameter is the explicit OP tenant identifier value that corresponds to the <tt>tenant</tt> claim the RP would like included in the ID Token. This parameter takes precedence over <tt>domain_hint</tt> when both are present.</t>
+<t>The <tt>tenant</tt> parameter value MUST match one of the following:
+- The value <tt>personal</tt> to indicate the RP would like the user to use an account managed by the user (personal account)
+- The value <tt>organization</tt> to indicate the RP would like the user to use an account managed by an organization (organizational account)
+- A stable, opaque OP tenant identifier value for multi-tenant OPs</t>
+<t>If the <tt>tenant</tt> parameter value does not match any OP tenant, the OP SHOULD return an <tt>invalid_request</tt> error or proceed with the authentication using the OP's default tenant selection logic. The specific behavior is implementation-dependent.</t>
+</section>
+
+<section anchor="client-tenant"><name>client_tenant</name>
+<t>The <tt>client_tenant</tt> parameter is an OPTIONAL parameter that the RP includes to communicate its RP tenant identifier to the OP. This parameter is used when the RP is multi-tenant and uses a shared <tt>client_id</tt> across multiple RP tenants (see Appendix A for details on multi-tenant RP models).</t>
+<t>The client MAY register allowed tenants using the <tt>tenants</tt> client registration parameter. When the <tt>client_tenant</tt> authentication request parameter is provided, the OP SHOULD validate that the <tt>client_tenant</tt> value corresponds to a valid RP tenant identifier that was registered for this client.</t>
+<t>The <tt>client_tenant</tt> parameter value MUST be a stable identifier that is unique within the context of the <tt>client_id</tt> used in the authentication request, ensuring that when multiple RP tenants share the same <tt>client_id</tt>, each tenant can be uniquely identified. The value is opaque to the OP (the OP does not need to understand its semantic meaning) and MUST be echoed back in the <tt>aud_tenant</tt> claim.</t>
+<t>The OP MUST treat the <tt>redirect_uri</tt> as opaque and MUST NOT attempt to identify an RP tenant from a specific URL endpoint or pattern.</t>
+<t>When the RP uses only the <tt>state</tt> parameter or session context for tenant routing and does not provide a <tt>client_tenant</tt> parameter, the OP MUST omit the <tt>aud_tenant</tt> claim from the ID Token.</t>
+<t>If the <tt>client_tenant</tt> parameter is provided but the OP cannot determine the corresponding RP tenant (e.g., the value doesn't match any registered tenant identifier for the <tt>client_id</tt>), the OP SHOULD return an <tt>invalid_request</tt> error with an appropriate error description.</t>
+<t>If an RP is multi-tenant and uses a shared <tt>client_id</tt> but does not provide a <tt>client_tenant</tt> parameter, the OP MAY:
+- Attempt to resolve the RP tenant identifier using other available information (e.g., <tt>domain_hint</tt>, <tt>login_hint</tt>)
+- Select a default tenant for the client or fallback behavior (implementation-dependent)
+- Prompt the end-user to select a valid tenant for the client
+- Return an <tt>invalid_request</tt> error indicating that tenant identification is required</t>
+<t>If the OP successfully determines the RP tenant identifier through any of these means, it SHOULD include it in the <tt>aud_tenant</tt> claim of the ID Token.</t>
+<t>If the OP does not support RP tenant identification and receives a <tt>client_tenant</tt> parameter, the OP SHOULD ignore the parameter and MUST omit the <tt>aud_tenant</tt> claim from the ID Token.</t>
+</section>
+</section>
+
+<section anchor="client-registration-parameters"><name>Client Registration Parameters</name>
+<t>Client registration is defined in [OpenID Connect Dynamic Client Registration 1.0].</t>
+<t>Following are OPTIONAL client registration parameters that may be included during client registration:</t>
+
+<section anchor="tenants"><name>tenants</name>
+<t>The <tt>tenants</tt> parameter is a JSON array of strings that represents RP tenant identifiers. This parameter is OPTIONAL and MAY be included during client registration.</t>
+<t>When the <tt>client_tenant</tt> authentication request parameter is provided, the OP MAY use the <tt>tenants</tt> client registration parameter to validate that the <tt>client_tenant</tt> value corresponds to a valid RP tenant identifier that was registered for this client. The OP can use this information to apply RP tenant-specific policies or to validate the authentication request.</t>
+<t>If an RP registers the <tt>tenants</tt> client registration parameter, OPs SHOULD assume the RP is multi-tenant.</t>
+<t>For example:</t>
+
+<sourcecode type="json"><![CDATA[{
+  "client_id": "rp-shared-abcde",
+  "redirect_uris": ["https://app.example.com/callback"],
+  "tenants": ["acme-corp-tenant-id", "widgets-inc-tenant-id"]
+}
+]]></sourcecode>
+</section>
+</section>
+
+<section anchor="login-from-a-third-party-parameters"><name>Login from a Third Party Parameters</name>
+<t>Initiating a login from a third party and a login initiation endpoint are defined in Section 4 of [OpenID Connect Core 1.0].</t>
+<t>Following are OPTIONAL parameters that may be included in request to the login initiation endpoint:</t>
+
+<section anchor="client-id"><name>client_id</name>
+<t>The <tt>client_id</tt> value the RP should use when making the Authentication Request. This allows a multi-tenant application that hosts multiple tenants, each represented by a different <tt>client_id</tt>, to know which <tt>client_id</tt> to use.</t>
+</section>
+
+<section anchor="domain-hint-1"><name>domain_hint</name>
+<t>The <tt>domain_hint</tt> value to be included in the Authentication Request.</t>
+</section>
+
+<section anchor="tenant-2"><name>tenant</name>
+<t>The <tt>tenant</tt> value to be included in the Authentication Request.</t>
+</section>
+
+<section anchor="client-tenant-1"><name>client_tenant</name>
+<t>The <tt>client_tenant</tt> value to be included in the Authentication Request.</t>
+</section>
+</section>
+
+<section anchor="security-considerations"><name>Security Considerations</name>
+
+<section anchor="op-security-considerations"><name>OP Security Considerations</name>
+
+<section anchor="tenant-isolation"><name>Tenant Isolation</name>
+<t>OPs MUST ensure strict isolation between tenants. An authenticated user from one OP tenant MUST NOT be able to obtain tokens containing a different tenant's identifier. The OP MUST validate that the <tt>tenant</tt> claim (see Section &quot;ID Token Claims&quot;) in issued ID Tokens accurately reflects the tenant context in which the user authenticated.</t>
+</section>
+
+<section anchor="client-tenant-validation"><name>Client Tenant Validation</name>
+<t>When the OP receives a <tt>client_tenant</tt> authentication request parameter (see Section &quot;Authentication Request Parameters&quot;), the OP SHOULD validate that the value corresponds to a registered RP tenant identifier for the given <tt>client_id</tt>. If the OP has registered the <tt>tenants</tt> client registration parameter (see Section &quot;Client Registration Parameters&quot;) for the client, the OP SHOULD reject requests where <tt>client_tenant</tt> is not in the registered list.</t>
+<t>Failure to validate the <tt>client_tenant</tt> parameter could allow an attacker to request tokens for arbitrary RP tenants, potentially bypassing RP tenant-specific policies configured at the OP.</t>
+</section>
+
+<section anchor="subject-identifier-collision"><name>Subject Identifier Collision</name>
+<t>Multi-tenant OPs MUST ensure that subject identifiers are unambiguous across tenants to prevent account confusion where an RP incorrectly links accounts from different OP tenants.</t>
+<t>For multi-tenant OPs using a single issuer (see Appendix A), the OP MUST ensure that subject identifiers are unambiguous across tenants. If the same <tt>sub</tt> value could exist in multiple OP tenants, the OP MUST include the <tt>tenant</tt> claim (see Section &quot;ID Token Claims&quot;) in the ID Token to enable RPs to correctly identify the account. The combination of <tt>iss</tt> + <tt>tenant</tt> + <tt>sub</tt> (for public subject identifiers) or <tt>iss</tt> + <tt>tenant</tt> + <tt>client_id</tt> + <tt>sub</tt> (for pairwise subject identifiers) MUST be unique across all tenants (see Appendix A for detailed requirements).</t>
+<t>For multi-tenant OPs using tenant-specific issuer identifiers (see Appendix A), the OP MUST ensure that the combination of <tt>iss</tt> + <tt>sub</tt> (for public subject identifiers) or <tt>iss</tt> + <tt>client_id</tt> + <tt>sub</tt> (for pairwise subject identifiers) is unique across all tenants. Since each tenant has a different issuer identifier, the OIDC Core requirement that <tt>sub</tt> is unique within <tt>iss</tt> already ensures tenant isolation. However, the OP MUST ensure uniqueness across all tenants, regardless of whether a client is shared across tenants or unique per tenant (see Appendix A for detailed requirements).</t>
+</section>
+
+<section anchor="token-injection-prevention"><name>Token Injection Prevention</name>
+<t>OPs SHOULD implement measures to prevent token injection attacks where an attacker attempts to replay tokens across tenant boundaries. This includes ensuring that tokens issued for one tenant context cannot be used to authenticate to a different tenant.</t>
+</section>
+</section>
+
+<section anchor="rp-security-considerations"><name>RP Security Considerations</name>
+
+<section anchor="tenant-claim-validation"><name>Tenant Claim Validation</name>
+<t>When an RP expects to receive the <tt>tenant</tt> claim (see Section &quot;ID Token Claims&quot;) (e.g., when authenticating to a multi-tenant OP using a single issuer, as described in Appendix A), the RP MUST validate that the <tt>tenant</tt> claim is present in the ID Token. If the RP has prior knowledge of the expected tenant (e.g., from a previous authentication or configuration), the RP SHOULD validate that the received <tt>tenant</tt> claim matches the expected value.</t>
+<t>Failure to validate the <tt>tenant</tt> claim could result in:
+- Account confusion where users from different OP tenants are incorrectly linked
+- Privilege escalation if tenant-specific access controls are bypassed</t>
+</section>
+
+<section anchor="aud-tenant-claim-validation"><name>aud_tenant Claim Validation</name>
+<t>When an RP sends the <tt>client_tenant</tt> authentication request parameter (see Section &quot;Authentication Request Parameters&quot;), the RP MUST validate that the returned <tt>aud_tenant</tt> claim (see Section &quot;ID Token Claims&quot;) matches the value sent in the request. If the <tt>aud_tenant</tt> claim is missing or contains a different value, the RP MUST reject the ID Token.</t>
+<t>This validation prevents an attacker from obtaining a token intended for one RP tenant and using it to authenticate to a different RP tenant. See Appendix A for details on how the <tt>client_tenant</tt> parameter relates to the <tt>aud_tenant</tt> claim.</t>
+</section>
+
+<section anchor="account-identifier-uniqueness"><name>Account Identifier Uniqueness</name>
+<t>RPs MUST use the complete set of identifying claims when linking accounts:
+- For multi-tenant OPs using a single issuer (see Appendix A): <tt>iss</tt> + <tt>tenant</tt> (see Section &quot;ID Token Claims&quot;) + <tt>sub</tt>
+- For multi-tenant OPs using tenant-specific issuers (see Appendix A): <tt>iss</tt> + <tt>sub</tt>
+- For multi-tenant RPs with shared <tt>client_id</tt> (see Appendix A): <tt>aud</tt> + <tt>aud_tenant</tt> (see Section &quot;ID Token Claims&quot;) + <tt>aud_sub</tt> (see Section &quot;ID Token Claims&quot;) (when present)</t>
+<t>Using only a subset of these claims (e.g., only <tt>sub</tt>) could result in incorrectly linking accounts from different tenants.</t>
+</section>
+
+<section anchor="cross-tenant-request-forgery"><name>Cross-Tenant Request Forgery</name>
+<t>Multi-tenant RPs MUST ensure that authentication responses are processed in the correct tenant context. When using the <tt>state</tt> parameter or session context for tenant routing, the RP MUST validate that the response is processed by the same tenant that initiated the request. Failure to do so could allow an attacker to initiate authentication in one RP tenant and have the response processed in a different RP tenant.</t>
+</section>
+</section>
+</section>
+
+<section anchor="privacy-considerations"><name>Privacy Considerations</name>
+<t><em>To be completed.</em></t>
+</section>
+
+<section anchor="iana-considerations"><name>IANA Considerations</name>
+<t><em>To be completed.</em></t>
+</section>
+
+<section anchor="references"><name>References</name>
+
+<section anchor="normative-references"><name>Normative References</name>
+
+<ul spacing="compact">
+<li><strong>[RFC2119]</strong> Bradner, S. &quot;Key words for use in RFCs to Indicate Requirement Levels,&quot; <em>RFC 2119</em>, March 1997.</li>
+<li><strong>[OpenID Connect Core 1.0]</strong> – &quot;OpenID Connect Core 1.0 incorporating errata set 2,&quot; available at <eref target="https://openid.net/specs/openid-connect-core-1_0.html">https://openid.net/specs/openid-connect-core-1_0.html</eref>.</li>
+<li><strong>[OpenID Connect Discovery 1.0]</strong> – &quot;OpenID Connect Discovery 1.0 incorporating errata set 2,&quot; available at <eref target="https://openid.net/specs/openid-connect-discovery-1_0.html">https://openid.net/specs/openid-connect-discovery-1_0.html</eref>.</li>
+<li><strong>[OpenID Connect Dynamic Client Registration 1.0]</strong> – &quot;OpenID Connect Dynamic Client Registration 1.0 incorporating errata set 2,&quot; available at <eref target="https://openid.net/specs/openid-connect-registration-1_0.html">https://openid.net/specs/openid-connect-registration-1_0.html</eref>.</li>
+</ul>
+</section>
+
+<section anchor="informative-references"><name>Informative References</name>
+
+<ul spacing="compact">
+<li><strong>IANA JSON Web Token Claims Registry</strong>, available at <eref target="https://www.iana.org/assignments/jwt/jwt.xhtml">https://www.iana.org/assignments/jwt/jwt.xhtml</eref>.</li>
+<li><strong>IANA OAuth Parameters</strong>, available at <eref target="https://www.iana.org/assignments/oauth-parameters/oauth-parameters.xhtml#client-metadata">https://www.iana.org/assignments/oauth-parameters/oauth-parameters.xhtml#client-metadata</eref>.</li>
+</ul>
+</section>
+</section>
+
+</middle>
+
+<back>
+
+<section anchor="enterprise-tenancy-models"><name>Enterprise Tenancy Models</name>
+<t>This appendix is non-normative.</t>
+<t>This appendix explains the relationships between issuer, client, and tenant for an OpenID Provider (OP) and Relying Party (RP). Understanding these models is helpful for correctly implementing the claims and parameters defined in this specification.</t>
+<t>The following diagram illustrates the relationship between OP tenants, RP tenants, and accounts:</t>
+
+<artwork><![CDATA[┌─────────────────────────────────────────────────────────────┐
+│                  OpenID Provider (OP)                       │
+│                                                             │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐       │
+│  │ OP Tenant A  │  │ OP Tenant B  │  │ OP Tenant C  │       │
+│  │              │  │              │  │              │       │
+│  │ ┌──────────┐ │  │ ┌──────────┐ │  │ ┌──────────┐ │       │
+│  │ │ Account 1│ │  │ │ Account 1│ │  │ │ Account 1│ │       │
+│  │ │ Account 2│ │  │ │ Account 2│ │  │ │ Account 2│ │       │
+│  │ └──────────┘ │  │ └──────────┘ │  │ └──────────┘ │       │
+│  └──────────────┘  └──────────────┘  └──────────────┘       │
+│                                                             │
+│  Identified by: `iss` + `tenant` (single issuer model)      │
+│  or by: `iss` alone (tenant-specific issuer model)          │
+└─────────────────────────────────────────────────────────────┘
+                            │
+                            │ Authentication
+                            │
+┌─────────────────────────────────────────────────────────────┐
+│                  Relying Party (RP)                         │
+│                                                             │
+│  ┌──────────────┐  ┌──────────────┐                         │
+│  │ RP Tenant X  │  │ RP Tenant Y  │                         │
+│  │              │  │              │                         │
+│  │ ┌──────────┐ │  │ ┌──────────┐ │                         │
+│  │ │ Account 1│ │  │ │ Account 1│ │                         │
+│  │ │ Account 2│ │  │ │ Account 2│ │                         │
+│  │ └──────────┘ │  │ └──────────┘ │                         │
+│  └──────────────┘  └──────────────┘                         │
+│                                                             │
+│  Identified by: `aud` (unique client per tenant)            │
+│  or by: `aud` + `aud_tenant` (shared client model)          │
+└─────────────────────────────────────────────────────────────┘
+]]></artwork>
+
+<section anchor="op-tenancy"><name>OP Tenancy</name>
+<t>An OP can have a single-tenant issuer or a multi-tenant issuer:</t>
+
+<ul>
+<li><t><strong>Single-tenant OP</strong>: The OP has a single tenant. All accounts are associated with this single tenant.</t>
+
+<ul>
+<li><t><strong>Issuer Configuration</strong>: The issuer identifier (<tt>iss</tt>) uniquely identifies the OP. The OP has a single OP metadata endpoint and signing keys.</t>
+</li>
+<li><t><strong>Subject Identifier Uniqueness</strong>:</t>
+
+<ul spacing="compact">
+<li>If the OP uses <tt>pairwise</tt> subject identifiers, the <tt>sub</tt> value for the same user will differ across different <tt>client_id</tt> values.</li>
+<li>If the OP uses <tt>public</tt> subject identifiers, the <tt>sub</tt> value will be the same across all RPs/clients.</li>
+</ul></li>
+</ul></li>
+</ul>
+<t>For example:</t>
+
+<sourcecode type="json"><![CDATA[  {
+    "iss": "https://idp.example.com",
+    "sub": "user123"
+  }
+]]></sourcecode>
+
+<ul>
+<li><t><strong>Multi-tenant OP</strong>: The OP has multiple tenants. Multi-tenant OPs may use a single issuer identifier for all tenants, or tenant-specific issuer identifiers:</t>
+
+<ul>
+<li><t><strong>Single issuer for all tenants</strong>: The OP uses one issuer identifier for all tenants, and the <tt>tenant</tt> claim (see Section &quot;ID Token Claims&quot;) distinguishes between tenants.</t>
+
+<ul>
+<li><t><strong>Issuer Configuration</strong>: All tenants share the same issuer identifier (<tt>iss</tt>), OP metadata endpoint, and signing keys.</t>
+</li>
+<li><t><strong>Subject Identifier Uniqueness</strong>:</t>
+
+<ul spacing="compact">
+<li>The combination of <tt>iss</tt> (issuer identifier), <tt>tenant</tt> (OP tenant identifier), and <tt>sub</tt> (subject identifier) MUST be unique across all tenants. This ensures that a subject identifier is unambiguous within the context of the OP, even when the same <tt>sub</tt> value might exist in different OP tenants.</li>
+<li>If the OP uses <tt>pairwise</tt> subject identifiers, the <tt>sub</tt> value for the same user MUST differ across different <tt>client_id</tt> values, but the same user MAY have the same <tt>sub</tt> value for the same <tt>client_id</tt> regardless of which OP tenant they authenticate to.  The OP is not required to have unique <tt>pairwise</tt> subject identifiers for clients that are shared across tenants per [OpenID Connect Core 1.0] Section 8.1. The <tt>tenant</tt> claim SHOULD be included in the uniqueness requirement (<tt>iss</tt> + <tt>tenant</tt> + <tt>sub</tt>) to disambiguate subjects across tenants.</li>
+<li>If the OP uses <tt>public</tt> subject identifiers, the <tt>sub</tt> value MUST be the same across all RPs/clients and all OP tenants. The <tt>tenant</tt> claim MUST be included in the uniqueness requirement (<tt>iss</tt> + <tt>tenant</tt> + <tt>sub</tt>) to disambiguate subjects across tenants.</li>
+</ul></li>
+</ul></li>
+</ul>
+<t>For example:</t>
+<t>Acme Corporation OP Tenant</t>
+
+<sourcecode type="json"><![CDATA[{
+  "iss": "https://idp.example.com",
+  "tenant": "acme-corp",
+  "sub": "user123"
+}
+]]></sourcecode>
+<t>Widgets Inc. OP Tenant</t>
+
+<sourcecode type="json"><![CDATA[{
+  "iss": "https://idp.example.com",
+  "tenant": "widgets-inc",
+  "sub": "user456"
+}
+]]></sourcecode>
+
+<ul>
+<li><t><strong>Tenant-specific issuer identifiers</strong>: The OP uses different issuer identifiers per tenant.</t>
+
+<ul>
+<li><t><strong>Issuer Configuration</strong>: Each tenant has its own issuer identifier (<tt>iss</tt>), OP metadata endpoint, and signing keys. Each issuer identifier MUST be a valid URL per [OpenID Connect Core 1.0] Section 2.</t>
+</li>
+<li><t><strong>Subject Identifier Uniqueness</strong>:</t>
+
+<ul spacing="compact">
+<li>The combination of <tt>iss</tt> (issuer identifier) and <tt>sub</tt> (subject identifier) MUST be unique. Since each issuer identifier identifies a specific tenant, the OIDC Core requirement that <tt>sub</tt> is unique within <tt>iss</tt> already ensures tenant isolation.</li>
+<li>If the OP uses <tt>pairwise</tt> subject identifiers, the <tt>sub</tt> value for the same user MUST differ across different <tt>client_id</tt> values within each tenant. The combination of <tt>iss</tt> + <tt>client_id</tt> + <tt>sub</tt> MUST be unique across all tenants, regardless of whether a client is shared across tenants or unique per tenant, since each tenant has a different issuer identifier.</li>
+<li>If the OP uses <tt>public</tt> subject identifiers, the <tt>sub</tt> value MUST be the same across all RPs/clients within each tenant. The <tt>sub</tt> value MAY be the same across tenants (a global <tt>sub</tt>), but the combination of <tt>iss</tt> + <tt>sub</tt> MUST be unique across all tenants since each tenant has a different issuer identifier.</li>
+</ul></li>
+</ul></li>
+</ul>
+<t>For example:</t>
+<t>Acme Corporation OP Tenant</t>
+
+<sourcecode type="json"><![CDATA[{
+  "iss": "https://acme-corp.idp.example.com",
+  "sub": "user123"
+}
+]]></sourcecode>
+<t>Widgets Inc. OP Tenant</t>
+
+<sourcecode type="json"><![CDATA[{
+  "iss": "https://widgets-inc.idp.example.com",
+  "sub": "user456"
+}
+]]></sourcecode>
+</li>
+</ul>
+<t>The following table summarizes OP tenancy models:</t>
+<table>
+<thead>
+<tr>
+<th>Model</th>
+<th>Issuer Configuration</th>
+<th>Uniqueness Requirement</th>
+<th>Tenant Identification</th>
+</tr>
+</thead>
+
+<tbody>
+<tr>
+<td>Single-tenant OP</td>
+<td>Single <tt>iss</tt>, single metadata endpoint, single signing keys</td>
+<td><tt>public</tt>: <tt>sub</tt> unique within <tt>iss</tt><br />
+<tt>pairwise</tt>: <tt>iss</tt> + <tt>client_id</tt> + <tt>sub</tt> unique</td>
+<td>Not applicable</td>
+</tr>
+
+<tr>
+<td>Multi-tenant OP (single issuer)</td>
+<td>Single <tt>iss</tt> shared across tenants, single metadata endpoint, single signing keys</td>
+<td><tt>public</tt>: <tt>iss</tt> + <tt>tenant</tt> + <tt>sub</tt> unique<br />
+<tt>pairwise</tt>: <tt>iss</tt> + <tt>tenant</tt> + <tt>client_id</tt> + <tt>sub</tt> unique</td>
+<td><tt>tenant</tt> claim in ID Token (see Section &quot;ID Token Claims&quot;)</td>
+</tr>
+
+<tr>
+<td>Multi-tenant OP (tenant-specific issuers)</td>
+<td>Each tenant has own <tt>iss</tt>, metadata endpoint, and signing keys</td>
+<td><tt>public</tt>: <tt>iss</tt> + <tt>sub</tt> unique (per tenant)<br />
+<tt>pairwise</tt>: <tt>iss</tt> + <tt>client_id</tt> + <tt>sub</tt> unique (per tenant)</td>
+<td><tt>iss</tt> value identifies tenant</td>
+</tr>
+</tbody>
+</table>
+<ul spacing="compact">
+<li><strong>Discovery</strong>: If an OP publishes support for the <tt>tenant</tt> claim in the <tt>claims_supported</tt> metadata parameter (see [OpenID Connect Discovery 1.0]), then RPs SHOULD assume that the issuer supports multiple tenants and SHOULD expect the <tt>tenant</tt> claim to be present in ID Tokens.</li>
+</ul>
+</section>
+
+<section anchor="op-tenant-communication"><name>OP Tenant Communication</name>
+<t>When the OP uses tenant-specific issuer identifiers, the RP authenticates to the appropriate issuer endpoint (e.g., <tt>https://acme-corp.idp.example.com</tt>), and the tenant is identified by the issuer identifier itself. In that model, OP tenant communication is not required.</t>
+<t>The following applies only to multi-tenant OPs that use a single issuer for all tenants. For such OPs, the RP MAY specify which OP tenant it wants the user to authenticate to using one of the following mechanisms:</t>
+
+<ul>
+<li><t><strong><tt>tenant</tt> parameter</strong>: The RP includes the <tt>tenant</tt> parameter in the authentication request with the OP tenant identifier value (e.g., <tt>tenant=acme-corp</tt>). When the OP receives this parameter, it SHOULD include the <tt>tenant</tt> claim in the ID Token with the same value. This is RECOMMENDED for RPs that know which <tt>tenant</tt> to make an authentication request to. See Section &quot;Authentication Request Parameters&quot; for details.</t>
+</li>
+<li><t><strong><tt>domain_hint</tt> parameter</strong>: The RP includes the <tt>domain_hint</tt> parameter with a domain name or email domain (e.g., <tt>example.com</tt>) that helps the OP identify the appropriate tenant. This is a user experience hint and is not guaranteed to uniquely identify a tenant. When both <tt>tenant</tt> and <tt>domain_hint</tt> are present, the <tt>tenant</tt> parameter takes precedence. If the OP cannot uniquely identify the tenant from <tt>domain_hint</tt> alone, the OP's tenant selection behavior is implementation-dependent. See Section &quot;Authentication Request Parameters&quot; for details.</t>
+</li>
+</ul>
+<t>When the OP tenant is not specified by the RP (neither <tt>tenant</tt> nor <tt>domain_hint</tt> is provided, or <tt>domain_hint</tt> does not uniquely identify a tenant), the OP MAY:
+- Provide a selector to allow the end-user to pick the tenant during authentication
+- Default to a specific tenant for the <tt>client_id</tt> and/or <tt>login_hint</tt>
+- Reject the request with an <tt>invalid_request</tt> error</t>
+<t>The following diagram illustrates OP tenant communication flow:</t>
+
+<artwork><![CDATA[┌─────────────────────┐                    ┌─────────────────────┐
+│         RP          │                    │         OP          │
+│                     │                    │                     │
+│ 1. RP determines    │                    │                     │
+│    desired OP       │                    │                     │
+│    tenant           │                    │                     │
+│    (from user       │                    │                     │
+│    input, config,   │                    │                     │
+│    etc.)            │                    │                     │
+│                     │                    │                     │
+│ 2. Authentication   │                    │                     │
+│    Request          │                    │                     │
+│    ├─ tenant=acme-  │                    │                     │
+│    │  corp          │                    │                     │
+│    │  (explicit)    │                    │                     │
+│    └─ OR            │                    │                     │
+│       domain_hint=  │                    │                     │
+│       acme.com      │                    │                     │
+│       (hint)        │                    │                     │
+│         │───────────────────────────────>│                     │
+│         │                                │                     │
+│         │                                │ 3. OP resolves      │
+│         │                                │    tenant context   │
+│         │                                │                     │
+│         │                                │ 4. User auth        │
+│         │                                │                     │
+│         │ 5. ID Token                    │                     │
+│         │    └─ tenant: "acme-corp"      │                     │
+│         │<───────────────────────────────│                     │
+│         │                                │                     │
+│ 6. RP validates     │                    │                     │
+│    tenant claim     │                    │                     │
+│    matches expected │                    │                     │
+│    tenant           │                    │                     │
+└─────────────────────┘                    └─────────────────────┘
+]]></artwork>
+</section>
+
+<section anchor="rp-tenancy"><name>RP Tenancy</name>
+<t>An RP can be single-tenant or multi-tenant:</t>
+
+<ul>
+<li><t><strong>Single-tenant RP</strong>: The RP has a single tenant. All accounts are associated with this single tenant.</t>
+
+<ul>
+<li><t><strong>Registration</strong>: The RP registers a single <tt>client_id</tt> with the OP issuer.</t>
+</li>
+<li><t><strong>Account Identifier Uniqueness</strong>: Account identifiers (such as <tt>aud_sub</tt> if present) MUST be unique within the context of that <tt>client_id</tt>.</t>
+</li>
+</ul></li>
+</ul>
+<t>For example:</t>
+
+<sourcecode type="json"><![CDATA[  {
+    "iss": "https://idp.example.com",
+    "sub": "user123",
+    "aud": "rp-single-tenant-xyz",
+    "aud_sub": "rp-account-123"
+  }
+]]></sourcecode>
+
+<ul>
+<li><t><strong>Multi-tenant RP</strong>: The RP has multiple tenants. Each tenant represents a distinct organizational or administrative boundary within the RP. Accounts are specific to the RP tenant. When an RP is multi-tenant, it needs to structure its client registration with the OP so that the OP can identify which RP tenant is making an authentication request. Multi-tenant RPs can use one of the following approaches:</t>
+
+<ul spacing="compact">
+<li><t><strong>Unique Client per Tenant</strong>: Each RP tenant has its own unique <tt>client_id</tt> registered with the OP issuer.</t>
+
+<ul spacing="compact">
+<li><strong>Registration</strong>: Each RP tenant registers its own unique <tt>client_id</tt> with the OP issuer.</li>
+<li><strong>Account Identifier Uniqueness</strong>: Account identifiers (such as <tt>aud_sub</tt> if present) MUST be unique within the context of that <tt>client_id</tt>.</li>
+</ul></li>
+</ul>
+<t>For example:
+ - RP tenant &quot;Acme Corp&quot; uses <tt>client_id</tt>: <tt>rp-acme-corp-12345</tt></t>
+
+<sourcecode type="json"><![CDATA[  {
+    "iss": "https://idp.example.com",
+    "sub": "user123",
+    "aud": "rp-acme-corp-12345",
+    "aud_sub": "acme-account-456"
+  }
+]]></sourcecode>
+
+<ul>
+<li><t>RP tenant &quot;Widgets Inc&quot; uses <tt>client_id</tt>: <tt>rp-widgets-inc-67890</tt></t>
+
+<sourcecode type="json"><![CDATA[{
+"iss": "https://idp.example.com",
+"sub": "user123",
+"aud": "rp-widgets-inc-67890",
+"aud_sub": "widgets-account-789"
+}
+]]></sourcecode>
+</li>
+<li><t><strong>Shared Client for all Tenants</strong>: Multiple RP tenants share a single <tt>client_id</tt> registered with the OP.</t>
+
+<ul spacing="compact">
+<li><strong>Registration</strong>: All RP tenants share a single <tt>client_id</tt> registered with the OP. The RP MAY register the <tt>tenants</tt> client registration parameter (see Section &quot;Client Registration Parameters&quot;) as a JSON array of strings containing the RP tenant identifiers.</li>
+<li><strong>Account Identifier Uniqueness</strong>: When both <tt>aud_tenant</tt> and <tt>aud_sub</tt> are present, their combination MUST be unique for a given <tt>aud</tt> (client identifier) within the RP. This ensures that account identifiers are unambiguous within the context of the RP, even when the same <tt>aud_sub</tt> value might exist in different RP tenants.</li>
+</ul></li>
+</ul>
+<t>For example:
+ - All RP tenants share <tt>client_id</tt>: <tt>rp-shared-abcde</tt>
+ - RP tenant &quot;Acme Corp&quot; is identified by the <tt>aud_tenant</tt> claim in the ID Token:</t>
+
+<sourcecode type="json"><![CDATA[  {
+    "iss": "https://idp.example.com",
+    "sub": "user123",
+    "aud": "rp-shared-abcde",
+    "aud_tenant": "acme-corp-tenant-id"
+  }
+]]></sourcecode>
+
+<ul spacing="compact">
+<li>RP tenant &quot;Widgets Inc&quot; is identified by the <tt>aud_tenant</tt> claim in the ID Token:</li>
+</ul>
+
+<sourcecode type="json"><![CDATA[  {
+    "iss": "https://idp.example.com",
+    "sub": "user456",
+    "aud": "rp-shared-abcde",
+    "aud_tenant": "widgets-inc-tenant-id"
+  }
+]]></sourcecode>
+</li>
+</ul>
+<t>The following table summarizes RP tenancy models:</t>
+<table>
+<thead>
+<tr>
+<th>Model</th>
+<th>Registration</th>
+<th>Account Identifier Uniqueness</th>
+<th>Tenant Identification</th>
+</tr>
+</thead>
+
+<tbody>
+<tr>
+<td>Single-tenant RP</td>
+<td>Single <tt>client_id</tt> registered with OP issuer</td>
+<td><tt>aud_sub</tt> unique within <tt>client_id</tt></td>
+<td>Not applicable</td>
+</tr>
+
+<tr>
+<td>Multi-tenant RP (unique client per tenant)</td>
+<td>Each tenant has own <tt>client_id</tt> registered with OP issuer</td>
+<td><tt>aud_sub</tt> unique within <tt>client_id</tt></td>
+<td><tt>aud</tt> identifies tenant</td>
+</tr>
+
+<tr>
+<td>Multi-tenant RP (shared client)</td>
+<td>Single <tt>client_id</tt> shared across tenants, <tt>tenants</tt> parameter MAY be registered</td>
+<td><tt>aud_tenant</tt> + <tt>aud_sub</tt> unique within <tt>aud</tt></td>
+<td><tt>aud</tt> + <tt>aud_tenant</tt> claim in ID Token (see Section &quot;ID Token Claims&quot;)</td>
+</tr>
+</tbody>
+</table>
+<ul spacing="compact">
+<li><strong>Discovery</strong>: If an RP supports multiple tenants and registers the <tt>tenants</tt> client registration parameter for the client, then OPs SHOULD assume the RP is multi-tenant.</li>
+</ul>
+</section>
+
+<section anchor="rp-tenant-communication"><name>RP Tenant Communication</name>
+<t>When an RP is multi-tenant and uses a shared <tt>client_id</tt>, the RP MAY communicate its tenant identifier to the OP, but is not required to do so. If the OP knows the RP tenant identifier, it SHOULD include it in the <tt>aud_tenant</tt> claim of the ID Token (see Section &quot;ID Token Claims&quot;).</t>
+<t>The RP can communicate its tenant identifier using one of the following mechanisms:</t>
+
+<ul>
+<li><t><strong><tt>client_tenant</tt> authentication request parameter</strong> (RECOMMENDED): The RP includes the <tt>client_tenant</tt> parameter in the authentication request with its tenant identifier value. This is explicit and unambiguous, allowing the OP to include the <tt>aud_tenant</tt> claim in the ID Token and apply RP tenant-specific policies (e.g., access control, consent requirements, authentication methods). When present, the OP MUST echo this value back in the <tt>aud_tenant</tt> claim. See Section &quot;Authentication Request Parameters&quot; for details.</t>
+</li>
+<li><t><strong><tt>state</tt> parameter or session context</strong>: RPs may include tenant identification information in the opaque <tt>state</tt> parameter of the OpenID Connect Authentication Request, or maintain tenant context via cookies or other session mechanisms. When the RP uses only this mechanism, the OP does not have access to the tenant identifier and MUST omit the <tt>aud_tenant</tt> claim from the ID Token. The OP cannot apply RP tenant-specific policies, and the RP MUST use implementation-specific mechanisms (such as parsing the <tt>state</tt> parameter or session context) to determine the tenant for routing the authentication response. This pattern is commonly used in practice.</t>
+</li>
+<li><t><strong><tt>redirect_uri</tt></strong>: RPs may register a <tt>redirect_uri</tt> per tenant and include the specific tenant redirect_uri in the OpenID Connect Authentication Request. The OP MUST treat the <tt>redirect_uri</tt> as opaque and MUST NOT attempt to identify a tenant from a specific URL endpoint or pattern. This mechanism only enables RP-side tenant routing; the OP cannot apply RP tenant-specific policies using this approach.</t>
+</li>
+</ul>
+<t>If the RP does not provide a <tt>client_tenant</tt> parameter and the OP cannot determine the RP tenant identifier from other mechanisms (such as <tt>state</tt> or <tt>redirect_uri</tt>), the OP MAY attempt to resolve the RP tenant using other available information (e.g., <tt>domain_hint</tt>, <tt>login_hint</tt>) or MAY select a default tenant for the client, or MAY prompt the end-user to select a valid tenant for the client. If the OP successfully determines the RP tenant identifier through any of these means, it SHOULD include it in the <tt>aud_tenant</tt> claim of the ID Token.</t>
+<t>The following diagram illustrates RP tenant communication flow:</t>
+
+<artwork><![CDATA[┌─────────────────────┐                    ┌─────────────────────┐
+│         RP          │                    │         OP          │
+│                     │                    │                     │
+│ 1. RP identifies    │                    │                     │
+│    its tenant       │                    │                     │
+│    context          │                    │                     │
+│    (e.g., from URL, │                    │                     │
+│    session, config) │                    │                     │
+│                     │                    │                     │
+│ 2. Authentication   │                    │                     │
+│    Request          │                    │                     │
+│    └─ client_tenant=│                    │                     │
+│       acme-corp-    │                    │                     │
+│       tenant-id     │                    │                     │
+│         │───────────────────────────────>│                     │
+│         │                                │                     │
+│         │                                │ 3. OP validates     │
+│         │                                │    client_tenant    │
+│         │                                │    (if tenants      │
+│         │                                │    registered)      │
+│         │                                │                     │
+│         │                                │ 4. User auth        │
+│         │                                │                     │
+│         │ 5. ID Token                    │                     │
+│         │    └─ aud_tenant:              │                     │
+│         │        "acme-corp-tenant-id"   │                     │
+│         │<───────────────────────────────│                     │
+│         │                                │                     │
+│ 6. RP validates     │                    │                     │
+│    aud_tenant claim │                    │                     │
+│    matches          │                    │                     │
+│    client_tenant    │                    │                     │
+│    sent and routes  │                    │                     │
+│    to correct       │                    │                     │
+│    tenant           │                    │                     │
+└─────────────────────┘                    └─────────────────────┘
+]]></artwork>
+</section>
+</section>
+
+<section anchor="acknowledgements"><name>Acknowledgements</name>
+<t><em>To be updated.</em></t>
+</section>
+
+<section anchor="notices"><name>Notices</name>
+<t>Copyright (c) 2025 The OpenID Foundation.</t>
+<t>The OpenID Foundation (OIDF) grants to any Contributor, developer,
+implementer, or other interested party a non-exclusive, royalty free,
+worldwide copyright license to reproduce, prepare derivative works from,
+distribute, perform and display, this Implementers Draft, Final
+Specification, or Final Specification Incorporating Errata Corrections
+solely for the purposes of (i) developing specifications,
+and (ii) implementing Implementers Drafts, Final Specifications,
+and Final Specification Incorporating Errata Corrections based
+on such documents, provided that attribution be made to the OIDF as the
+source of the material, but that such attribution does not indicate an
+endorsement by the OIDF.</t>
+<t>The technology described in this specification was made available
+from contributions from various sources, including members of the OpenID
+Foundation and others. Although the OpenID Foundation has taken steps to
+help ensure that the technology is available for distribution, it takes
+no position regarding the validity or scope of any intellectual property
+or other rights that might be claimed to pertain to the implementation
+or use of the technology described in this specification or the extent
+to which any license under such rights might or might not be available;
+neither does it represent that it has made any independent effort to
+identify any such rights. The OpenID Foundation and the contributors to
+this specification make no (and hereby expressly disclaim any)
+warranties (express, implied, or otherwise), including implied
+warranties of merchantability, non-infringement, fitness for a
+particular purpose, or title, related to this specification, and the
+entire risk as to implementing this specification is assumed by the
+implementer. The OpenID Intellectual Property Rights policy
+(found at openid.net) requires
+contributors to offer a patent promise not to assert certain patent
+claims against other contributors and against implementers.
+OpenID invites any interested party to bring to its attention any
+copyrights, patents, patent applications, or other proprietary rights
+that may cover technology that may be required to practice this
+specification.</t>
+</section>
+
+<section anchor="document-history"><name>Document History</name>
+<t>[[ To be removed from the final specification ]]</t>
+<t>-00</t>
+<t>initial draft</t>
+<t>-01</t>
+
+<ul spacing="compact">
+<li>added <tt>aud_sub</tt> claim</li>
+</ul>
+<t>-02</t>
+
+<ul spacing="compact">
+<li>added <tt>aud_tenant</tt> claim</li>
+<li>added <tt>client_tenant</tt> authentication request parameter</li>
+<li>added <tt>tenants</tt> client registration parameter</li>
+<li>added <tt>client_tenant</tt> to Login from a Third Party parameters</li>
+<li>added Tenancy Models appendix to describe OP and RP tenancy models and relationships</li>
+<li>added Security Considerations</li>
+</ul>
+</section>
+
+</back>
+
+</rfc>


### PR DESCRIPTION
Attempted to clarify a lot of repeated questions and ambiguity around OP vs RP tenants by adding a new section that describes valid tenancy models and how they related

Additionally added support for `aud_tenant` claim for RPs that share a client registration across OP Tenants and new request parameter `client_tenant` for the RP to signal and client registration parameter for the OP to know valid tenants

PR also includes security considerations to help folks understand tradeoffs 

The IETF [Identity Assertion JWT Authorization Grant  ](https://drafts.oauth.net/oauth-identity-assertion-authz-grant/draft-ietf-oauth-identity-assertion-authz-grant.html) already used `aud_sub` from this spec and needs `aud_tenant` as it can't rely on redirect_uris, state, or cookies to capture RP tenancy as the token obtained and passed on the backchannel without involving the user agent. Since ID-JAG is suppose to act as cross-domain identity assertion and I have included the registration here so ID Tokens flows can be the same.